### PR TITLE
ci: speed up release build with sccache + single cargo invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           cache: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Install musl-tools
         if: matrix.target == 'x86_64-unknown-linux-musl'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
   RELEASE_BINARIES: timsseek timsquery_cli timsquery_viewer speclib_build
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   build-and-release:
@@ -50,6 +53,9 @@ jobs:
           target: ${{ matrix.target }}
           cache: true
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Install musl-tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -57,9 +63,15 @@ jobs:
       - name: Build Binaries
         shell: bash
         run: |
+          bins=()
           for binary in $RELEASE_BINARIES; do
-            cargo build --release --bin $binary --target ${{ matrix.target }}
+            bins+=(--bin "$binary")
           done
+          cargo build --release --target ${{ matrix.target }} "${bins[@]}"
+
+      - name: sccache stats
+        shell: bash
+        run: sccache --show-stats
 
       - name: Package Artifacts
         shell: bash


### PR DESCRIPTION
## Summary
- Collapse 4 per-bin `cargo build` calls into one multi-`--bin` invocation to drop redundant workspace resolution/linking.
- Add `mozilla-actions/sccache-action` with GHA backend; stacks on top of existing `setup-rust-toolchain` cache (registry/target) for cross-branch rustc-output caching.
- `CARGO_INCREMENTAL=0` for smaller, more reusable release caches.
- Print `sccache --show-stats` post-build for hit-rate visibility.

Motivated by slow Windows jobs in recent release runs (linker-bound on msvc).

## Build artifact
Add the `build-artifact` label on this PR to trigger the release workflow and validate end-to-end on all 4 targets (linux-gnu, linux-musl, macos-arm64, windows-msvc). Check `sccache --show-stats` in the first run (expect misses) and a second re-run (expect hits) to confirm caching works.

## Test plan
- [ ] Apply `build-artifact` label
- [ ] First run completes on all targets; artifacts produced
- [ ] `sccache --show-stats` shows non-zero requests
- [ ] Re-run workflow; verify hit rate > 0 on second run
- [ ] Compare windows job duration vs. baseline (`v0.28.1` run: https://github.com/TalusBio/timsbuktoolkit/actions/runs/24541016760)