### PR TITLE
apex_sim: apex-finder simulator app + sensitivity bench

### DIFF
--- a/.github/workflows/apex_bench.yml
+++ b/.github/workflows/apex_bench.yml
@@ -1,0 +1,79 @@
+name: Apex Bench
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "rust/apex_sim/**"
+      - "rust/timsseek/**"
+      - ".github/workflows/apex_bench.yml"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+# Needed to upsert the sticky results comment on the PR.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Apply crate patches (rustyms gnome.dat stub)
+        run: |
+          cargo install --git https://github.com/jspaezp/cargo-patch-crate patch-crate --locked
+          cargo patch-crate
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: true
+
+      - name: Run apex_sim bench
+        id: bench
+        run: |
+          cargo run -p apex_sim --release --no-default-features --example bench -- 1000 2 > bench_out.txt
+          echo "----- bench output -----"
+          cat bench_out.txt
+
+      - name: Post results to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('bench_out.txt', 'utf8');
+            const marker = '<!-- apex-bench -->';
+            const body = [
+              marker,
+              '## Apex-finder bench',
+              '`cargo run -p apex_sim --release --example bench -- 1000 2`',
+              '',
+              '<details><summary>Sensitivity + timing across canonical scenarios</summary>',
+              '',
+              '```',
+              output.trim(),
+              '```',
+              '',
+              '</details>',
+              '',
+              `_commit ${context.sha.slice(0, 8)}_`,
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number },
+            );
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apex_sim"
+version = "0.31.0"
+dependencies = [
+ "eframe",
+ "egui",
+ "egui_plot",
+ "rand 0.9.3",
+ "rand_chacha 0.9.0",
+ "timsquery",
+ "timsseek",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "rust/timsquery",
     "rust/timsquery_cli",
     "rust/timsquery_viewer",
+    "rust/apex_sim",
     "rust/speclib_build_cli",
     "rust/tims_stage",
     "python/timsquery_pyo3"
@@ -26,6 +27,7 @@ default-members = [
     "rust/timsquery",
     "rust/timsquery_cli",
     "rust/timsquery_viewer",
+    "rust/apex_sim",
     "rust/speclib_build_cli",
     "rust/tims_stage"
 ]

--- a/rust/apex_sim/Cargo.toml
+++ b/rust/apex_sim/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "apex_sim"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "apex_sim"
+path = "src/main.rs"
+# The interactive app needs the GUI stack; skipped under --no-default-features.
+required-features = ["gui"]
+
+[features]
+default = ["gui"]
+# GUI feature: pulls the egui/eframe stack. Disable (--no-default-features) to
+# build just the simulation + scoring + bench, e.g. in CI, without egui/winit.
+gui = ["dep:egui", "dep:eframe", "dep:egui_plot"]
+
+[dependencies]
+timsseek = { path = "../timsseek" }
+timsquery = { path = "../timsquery" }
+
+# GUI (optional, gated behind the `gui` feature)
+egui = { version = "0.33", features = ["rayon"], optional = true }
+eframe = { version = "0.33", default-features = true, features = [
+  "default_fonts",
+], optional = true }
+egui_plot = { version = "0.34", optional = true }
+
+# Deterministic synthetic-data RNG
+rand = "0.9"
+rand_chacha = "0.9"

--- a/rust/apex_sim/examples/bench.rs
+++ b/rust/apex_sim/examples/bench.rs
@@ -1,0 +1,47 @@
+//! Apex-finder bench: runs the whole catalog of canonical scenarios
+//! (`apex_sim::bench::canonical_suite`) at once and prints per-scenario detail
+//! plus a comparison summary table.
+//!
+//! Each scenario runs `n_runs` seeds of one fixed config; "sensitivity" is the
+//! fraction of runs whose pass-2 apex lands within `tol` cycles of truth.
+//!
+//! Run:
+//!   cargo run -p apex_sim --release --example bench
+//!   cargo run -p apex_sim --release --example bench -- 500 2
+//!     (positional: <n_runs> <tolerance_cycles>)
+
+use apex_sim::bench::{
+    canonical_suite,
+    run_sensitivity,
+};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n_runs: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(2000);
+    let tol: i64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(2);
+
+    let suite = canonical_suite();
+    let mut rows = Vec::with_capacity(suite.len());
+    for (name, cfg) in &suite {
+        let report = run_sensitivity(cfg, n_runs, tol);
+        report.print(name);
+        println!();
+        rows.push((*name, report));
+    }
+
+    println!("=== summary (n={n_runs}, tol=±{tol} cycles) ===");
+    println!(
+        "  {:<26} {:>7} {:>7} {:>8} {:>9}",
+        "scenario", "pass2%", "pass1%", "medErr", "us/run"
+    );
+    for (name, r) in &rows {
+        println!(
+            "  {:<26} {:>7.1} {:>7.1} {:>8} {:>9.2}",
+            name,
+            r.pass2_pct(),
+            r.pass1_pct(),
+            r.median_err(),
+            r.score_us_per_run(),
+        );
+    }
+}

--- a/rust/apex_sim/src/app.rs
+++ b/rust/apex_sim/src/app.rs
@@ -1,0 +1,364 @@
+//! eframe application: control panel + stacked visualizations.
+
+use eframe::egui::{
+    self,
+    TextureHandle,
+};
+
+use crate::plots;
+use crate::scorer::{
+    self,
+    ScoreResult,
+};
+use crate::sim::{
+    self,
+    FragmentSpec,
+    SimData,
+    SimParams,
+};
+
+pub struct SimApp {
+    params: SimParams,
+    data: Option<SimData>,
+    score: Option<ScoreResult>,
+    score_err: Option<String>,
+    heatmap: Option<(TextureHandle, usize)>,
+    dirty: bool,
+}
+
+impl Default for SimApp {
+    fn default() -> Self {
+        Self {
+            params: SimParams::default(),
+            data: None,
+            score: None,
+            score_err: None,
+            heatmap: None,
+            dirty: true,
+        }
+    }
+}
+
+impl SimApp {
+    /// Rebuild the synthetic extraction, rescore it, and refresh the heatmap.
+    fn recompute(&mut self, ctx: &egui::Context) {
+        let data = sim::build(&self.params);
+
+        let map = self.params.rt_mapper();
+        match scorer::run(&data.extraction, &map) {
+            Ok(res) => {
+                self.score = Some(res);
+                self.score_err = None;
+            }
+            Err(e) => {
+                self.score = None;
+                self.score_err = Some(e);
+            }
+        }
+
+        self.heatmap = Some(plots::build_heatmap(ctx, &data));
+        self.data = Some(data);
+        self.dirty = false;
+    }
+}
+
+impl eframe::App for SimApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::SidePanel::left("controls")
+            .default_width(320.0)
+            .show(ctx, |ui| {
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    self.dirty |= controls(ui, &mut self.params);
+                    ui.separator();
+                    score_readout(ui, self.score.as_ref(), self.score_err.as_deref());
+                });
+            });
+
+        if self.dirty {
+            self.recompute(ctx);
+        }
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            let Some(data) = &self.data else { return };
+            let score = self.score.as_ref();
+            let true_apex = self.params.apex_cycle;
+
+            ui.heading("Chromatograms");
+            plots::apex_caption(ui);
+            plots::chromatograms(ui, data, score, true_apex);
+
+            ui.separator();
+            ui.heading("Heatmap (transitions x cycles)");
+            if let Some((tex, n_rows)) = &self.heatmap {
+                let _ = n_rows;
+                let n_cols = data
+                    .fragment_rows
+                    .first()
+                    .map(|r| r.intensities.len())
+                    .unwrap_or(1);
+                plots::heatmap(ui, tex, n_cols, score, true_apex);
+            }
+
+            ui.separator();
+            ui.heading("Apex-finder intermediate traces");
+            if let Some(score) = score {
+                plots::traces(
+                    ui,
+                    score,
+                    &TRACE_TOGGLES.with(|t| t.borrow().clone()),
+                    true_apex,
+                );
+            } else if let Some(err) = &self.score_err {
+                ui.colored_label(egui::Color32::from_rgb(220, 80, 80), err);
+            }
+        });
+    }
+
+    /// Dump the final simulation config to stdout on window close, so a run can
+    /// be reproduced or pasted into a test.
+    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+        println!("--- apex_sim final config ---\n{:#?}", self.params);
+    }
+}
+
+// Trace toggles kept in a thread-local so the checkbox row (rendered in the
+// central panel header) and the plot share one source of truth without
+// threading extra fields through every fn.
+thread_local! {
+    static TRACE_TOGGLES: std::cell::RefCell<plots::TraceToggles> =
+        std::cell::RefCell::new(plots::TraceToggles::default());
+}
+
+/// OR a widget's `changed()` into `flag`. Non-capturing so it can be used
+/// inside nested `ui.horizontal` closures without a persistent borrow.
+fn chg(flag: &mut bool, r: egui::Response) {
+    *flag |= r.changed();
+}
+
+/// Render every knob. Returns true if any value changed (=> recompute needed).
+fn controls(ui: &mut egui::Ui, p: &mut SimParams) -> bool {
+    let mut changed = false;
+
+    ui.heading("Simulation");
+
+    ui.label("Peak shape");
+    chg(
+        &mut changed,
+        ui.add(
+            egui::Slider::new(&mut p.apex_cycle, 0.0..=(p.n_cycles as f32 - 1.0))
+                .text("apex cycle"),
+        ),
+    );
+    chg(
+        &mut changed,
+        ui.add(egui::Slider::new(&mut p.width_sigma, 0.1..=5.0).text("width sigma")),
+    );
+    chg(
+        &mut changed,
+        ui.add(
+            egui::Slider::new(&mut p.height, 10.0..=10_000.0)
+                .logarithmic(true)
+                .text("height"),
+        ),
+    );
+    chg(
+        &mut changed,
+        ui.add(egui::Slider::new(&mut p.n_cycles, 10..=300).text("n cycles")),
+    );
+
+    ui.separator();
+    ui.label("Noise");
+    chg(
+        &mut changed,
+        ui.add(egui::Slider::new(&mut p.noise_floor, 0.0..=1.0).text("noise floor")),
+    );
+    if ui
+        .add(egui::Slider::new(&mut p.seed, 0..=999).text("seed"))
+        .changed()
+    {
+        changed = true;
+    }
+
+    ui.separator();
+    ui.label("Precursor");
+    chg(
+        &mut changed,
+        ui.add(egui::Slider::new(&mut p.n_isotopes, 1..=6).text("n isotopes")),
+    );
+    chg(
+        &mut changed,
+        ui.add(
+            egui::Slider::new(&mut p.precursor_intensity, 0.0..=2.0).text("precursor intensity"),
+        ),
+    );
+
+    ui.separator();
+    ui.horizontal(|ui| {
+        ui.label(format!("Real fragments ({})", p.real_fragments.len()));
+        if ui.button("+").clicked() {
+            let n = p.real_fragments.len();
+            p.real_fragments.push(FragmentSpec {
+                label: format!("?{n}"),
+                theo_intensity: 0.5,
+                obs_scale: 1.0,
+                noise_mult: 1.0,
+            });
+            changed = true;
+        }
+        if ui.button("-").clicked() && p.real_fragments.len() > 1 {
+            p.real_fragments.pop();
+            changed = true;
+        }
+    });
+    ui.label("theo = library ratio · obs = observed/theory (0 = absent)");
+    for f in p.real_fragments.iter_mut() {
+        ui.horizontal(|ui| {
+            ui.label(&f.label);
+            chg(
+                &mut changed,
+                ui.add(egui::Slider::new(&mut f.theo_intensity, 0.0..=1.0).text("theo")),
+            );
+            chg(
+                &mut changed,
+                ui.add(egui::Slider::new(&mut f.obs_scale, 0.0..=2.0).text("obs")),
+            );
+            chg(
+                &mut changed,
+                ui.add(egui::Slider::new(&mut f.noise_mult, 0.0..=5.0).text("noise x")),
+            );
+        });
+    }
+
+    ui.separator();
+    let rp = &mut p.random_peaks;
+    chg(
+        &mut changed,
+        ui.checkbox(&mut rp.enabled, "Random peak-like objects"),
+    );
+    if rp.enabled {
+        chg(
+            &mut changed,
+            ui.add(egui::Slider::new(&mut rp.count, 0..=100).text("count")),
+        );
+        ui.horizontal(|ui| {
+            chg(
+                &mut changed,
+                ui.add(egui::Slider::new(&mut rp.height_frac_min, 0.0..=10.0).text("h min")),
+            );
+            chg(
+                &mut changed,
+                ui.add(egui::Slider::new(&mut rp.height_frac_max, 0.0..=10.0).text("h max")),
+            );
+        });
+        ui.label("(width inherited from peptide σ)");
+        chg(
+            &mut changed,
+            ui.checkbox(&mut rp.hit_precursors, "also hit precursors"),
+        );
+    }
+
+    ui.separator();
+    ui.label("Traces to plot");
+    TRACE_TOGGLES.with(|t| {
+        let mut t = t.borrow_mut();
+        ui.checkbox(&mut t.cosine, "cosine");
+        ui.checkbox(&mut t.scribe, "scribe");
+        ui.checkbox(&mut t.lazyscore, "lazyscore");
+        ui.checkbox(&mut t.log_intensity, "log_intensity");
+        ui.checkbox(&mut t.ms1_precursor, "ms1_precursor");
+        ui.checkbox(&mut t.apex_profile, "apex_profile");
+    });
+
+    changed
+}
+
+/// Show the full `ApexScore` from pass 2 plus the pass-1 location.
+fn score_readout(ui: &mut egui::Ui, score: Option<&ScoreResult>, err: Option<&str>) {
+    ui.heading("Score");
+    let Some(s) = score else {
+        if let Some(e) = err {
+            ui.colored_label(egui::Color32::from_rgb(220, 80, 80), e);
+        } else {
+            ui.label("(no score)");
+        }
+        return;
+    };
+
+    let p2 = &s.pass2;
+    egui::Grid::new("score_grid").num_columns(2).show(ui, |ui| {
+        let row = |ui: &mut egui::Ui, k: &str, v: String| {
+            ui.label(k);
+            ui.label(v);
+            ui.end_row();
+        };
+        let sp = &p2.split_product;
+        row(ui, "pass1 apex cycle", s.pass1.apex_cycle.to_string());
+        row(ui, "pass1 score", format!("{:.3e}", s.pass1.score));
+        row(ui, "pass2 joint apex", p2.joint_apex_cycle.to_string());
+        row(ui, "pass2 score", format!("{:.3e}", p2.score));
+        row(ui, "rt (ms)", p2.retention_time_ms.to_string());
+        // Score = base_score * feature_product. Decompose so magnitude blowups
+        // (base ~ intensity^2 via the two area-uniqueness terms) are visible.
+        row(ui, "= base_score", format!("{:.3e}", sp.base_score));
+        row(
+            ui,
+            "  x feat_product",
+            format!("{:.3e}", safe_ratio(p2.score, sp.base_score)),
+        );
+        row(ui, "  cosine_au", format!("{:.3e}", sp.cosine_au));
+        row(ui, "  cosine_cg", format!("{:.3}", sp.cosine_cg));
+        row(ui, "  scribe_au", format!("{:.3e}", sp.scribe_au));
+        row(ui, "  scribe_cg", format!("{:.3}", sp.scribe_cg));
+        row(ui, "delta_next", format!("{:.4}", p2.delta_next));
+        row(ui, "delta_2nd_next", format!("{:.4}", p2.delta_second_next));
+        row(ui, "lazyscore", format!("{:.4}", p2.lazyscore));
+        row(ui, "lazyscore_z", format!("{:.4}", p2.lazyscore_z));
+        row(ui, "npeaks", p2.npeaks.to_string());
+        row(
+            ui,
+            "ms1 summed int",
+            format!("{:.1}", p2.ms1_summed_intensity),
+        );
+        row(
+            ui,
+            "ms2 summed int",
+            format!("{:.1}", p2.ms2_summed_intensity),
+        );
+        row(
+            ui,
+            "rising/falling",
+            format!("{}/{}", p2.rising_cycles, p2.falling_cycles),
+        );
+    });
+
+    ui.separator();
+    ui.label("11 features (each in [0,1])");
+    let f = &p2.features;
+    egui::Grid::new("feat_grid").num_columns(2).show(ui, |ui| {
+        let row = |ui: &mut egui::Ui, k: &str, v: f32| {
+            ui.label(k);
+            ui.label(format!("{v:.3}"));
+            ui.end_row();
+        };
+        row(ui, "peak_shape", f.peak_shape);
+        row(ui, "ratio_cv", f.ratio_cv);
+        row(ui, "centered_apex", f.centered_apex);
+        row(ui, "precursor_coelution", f.precursor_coelution);
+        row(ui, "fragment_coverage", f.fragment_coverage);
+        row(ui, "precursor_apex_match", f.precursor_apex_match);
+        row(ui, "xic_quality", f.xic_quality);
+        row(ui, "fragment_apex_agreement", f.fragment_apex_agreement);
+        row(ui, "isotope_correlation", f.isotope_correlation);
+        row(ui, "gaussian_correlation", f.gaussian_correlation);
+        row(ui, "per_frag_gaussian_corr", f.per_frag_gaussian_corr);
+    });
+}
+
+/// `a / b`, or 0 when `b` is 0 / non-finite (avoids NaN/inf in the readout).
+fn safe_ratio(a: f32, b: f32) -> f32 {
+    if b.abs() > 0.0 && b.is_finite() {
+        a / b
+    } else {
+        0.0
+    }
+}

--- a/rust/apex_sim/src/bench.rs
+++ b/rust/apex_sim/src/bench.rs
@@ -1,0 +1,248 @@
+//! Shared sensitivity-bench harness used by the `examples/` benches.
+//!
+//! Runs the SAME simulation config over many seeds (each a fresh noise +
+//! random-peak realization), scoring every one with the real `timsseek` apex
+//! finder, and measures how reliably the apex is recovered plus how fast the
+//! scoring runs. Simulation is built up front so its cost stays OUT of the
+//! scoring timer; the scorer is reused across runs (no per-run alloc/clone),
+//! mirroring production's `ScoringWorker`.
+
+use std::time::Instant;
+
+use timsseek::scoring::apex_finding::TraceScorer;
+
+use crate::scorer;
+use crate::sim::{
+    self,
+    SimData,
+    SimParams,
+};
+
+/// Aggregate results of a sensitivity run.
+pub struct SensitivityReport {
+    pub n: usize,
+    pub tol: i64,
+    pub true_apex: i64,
+    pub build_ms: f64,
+    pub score_ms: f64,
+    pub errors: usize,
+    pub pass1_hits: usize,
+    pub pass2_hits: usize,
+    /// Sorted pass-2 |apex - truth| per successful run.
+    pub abs_err: Vec<i64>,
+    // Echoed config for the printout.
+    pub n_cycles: usize,
+    pub width_sigma: f32,
+    pub noise_floor: f32,
+    pub random_peaks: usize,
+}
+
+fn pct(num: usize, den: usize) -> f64 {
+    if den == 0 {
+        0.0
+    } else {
+        100.0 * num as f64 / den as f64
+    }
+}
+
+/// The canonical benchmark scenarios, run together by `examples/bench.rs`.
+/// All share the same peptide geometry (245 cycles, apex@30, sigma 1, seed
+/// 680); each isolates one stressor so the summary table reads as an ablation.
+pub fn canonical_suite() -> Vec<(&'static str, SimParams)> {
+    let base = || {
+        let mut p = SimParams::default();
+        p.n_cycles = 245;
+        p.apex_cycle = 30.0;
+        p.width_sigma = 1.0;
+        p.seed = 680;
+        p
+    };
+
+    // Baseline: low noise, no interference -> should be near-perfect.
+    let mut clean = base();
+    clean.noise_floor = 0.02;
+    clean.random_peaks.enabled = false;
+
+    // Moderate noise + light interference.
+    let mut moderate = base();
+    moderate.noise_floor = 0.2;
+    moderate.random_peaks.count = 50;
+
+    // High noise + heavy interference (the main stress condition).
+    let mut stress = base();
+    stress.noise_floor = 0.5;
+    stress.random_peaks.count = 100;
+
+    // Even more injected peaks at the same noise.
+    let mut heavy = base();
+    heavy.noise_floor = 0.5;
+    heavy.random_peaks.count = 300;
+
+    // Mismatched library at stress level: flat theoretical ratios, observed
+    // keeps the descending ladder (cross-instrument speclib case).
+    let mut mismatched = base();
+    mismatched.noise_floor = 0.5;
+    mismatched.random_peaks.count = 100;
+    for f in &mut mismatched.real_fragments {
+        f.obs_scale = f.theo_intensity;
+        f.theo_intensity = 1.0;
+    }
+
+    // Absent top fragment at stress level (expected but observed as noise).
+    let mut absent = base();
+    absent.noise_floor = 0.5;
+    absent.random_peaks.count = 100;
+    absent.real_fragments[0].obs_scale = 0.0;
+
+    vec![
+        ("clean", clean),
+        ("moderate_noise", moderate),
+        ("high_noise+interference", stress),
+        ("heavy_interference", heavy),
+        ("mismatched_library", mismatched),
+        ("absent_top_fragment", absent),
+    ]
+}
+
+/// Run `n_runs` scored simulations of `base` (varying only the seed) and
+/// collect apex-recovery + timing stats. A hit = pass-2 apex within `tol`
+/// cycles of the configured `apex_cycle`.
+pub fn run_sensitivity(base: &SimParams, n_runs: usize, tol: i64) -> SensitivityReport {
+    let true_apex = base.apex_cycle.round() as i64;
+    // rt mapping is seed-independent, so one mapper serves every run.
+    let map = base.rt_mapper();
+
+    // Phase 1: build ALL extractions up front (kept out of the timed loop).
+    let t_build = Instant::now();
+    let sims: Vec<SimData> = (0..n_runs)
+        .map(|i| {
+            let mut p = base.clone();
+            p.seed = base.seed.wrapping_add(i as u64); // independent realization
+            sim::build(&p)
+        })
+        .collect();
+    let build_ms = t_build.elapsed().as_secs_f64() * 1e3;
+
+    // Phase 2: time ONLY the scoring. One reusable scorer, no per-run alloc.
+    let mut errors = 0;
+    let mut pass1_hits = 0;
+    let mut pass2_hits = 0;
+    let mut abs_err = Vec::with_capacity(n_runs);
+    let mut scorer = TraceScorer::new(base.n_cycles, base.real_fragments.len().max(1));
+    let t_score = Instant::now();
+    for data in &sims {
+        match scorer::run_with(&mut scorer, &data.extraction, &map) {
+            Ok((pass1, pass2)) => {
+                if (pass1.apex_cycle as i64 - true_apex).abs() <= tol {
+                    pass1_hits += 1;
+                }
+                let e2 = (pass2.joint_apex_cycle as i64 - true_apex).abs();
+                if e2 <= tol {
+                    pass2_hits += 1;
+                }
+                abs_err.push(e2);
+            }
+            Err(_) => errors += 1,
+        }
+    }
+    let score_ms = t_score.elapsed().as_secs_f64() * 1e3;
+
+    abs_err.sort_unstable();
+    SensitivityReport {
+        n: n_runs,
+        tol,
+        true_apex,
+        build_ms,
+        score_ms,
+        errors,
+        pass1_hits,
+        pass2_hits,
+        abs_err,
+        n_cycles: base.n_cycles,
+        width_sigma: base.width_sigma,
+        noise_floor: base.noise_floor,
+        random_peaks: base.random_peaks.count,
+    }
+}
+
+impl SensitivityReport {
+    pub fn pass1_pct(&self) -> f64 {
+        pct(self.pass1_hits, self.n)
+    }
+
+    pub fn pass2_pct(&self) -> f64 {
+        pct(self.pass2_hits, self.n)
+    }
+
+    pub fn median_err(&self) -> i64 {
+        self.abs_err
+            .get(self.abs_err.len() / 2)
+            .copied()
+            .unwrap_or(-1)
+    }
+
+    pub fn score_us_per_run(&self) -> f64 {
+        self.score_ms * 1e3 / self.n.max(1) as f64
+    }
+
+    /// Print a human-readable summary under `title`.
+    pub fn print(&self, title: &str) {
+        let median = self
+            .abs_err
+            .get(self.abs_err.len() / 2)
+            .copied()
+            .unwrap_or(-1);
+        let mean = if self.abs_err.is_empty() {
+            f64::NAN
+        } else {
+            self.abs_err.iter().sum::<i64>() as f64 / self.abs_err.len() as f64
+        };
+        let max = self.abs_err.last().copied().unwrap_or(-1);
+        let score_us = self.score_ms * 1e3 / self.n.max(1) as f64;
+        let build_us = self.build_ms * 1e3 / self.n.max(1) as f64;
+        let throughput = self.n as f64 / (self.score_ms / 1e3).max(1e-12);
+
+        println!("=== {title} ===");
+        println!(
+            "  config: n_cycles={} sigma={} noise_floor={} random_peaks={} true_apex={}",
+            self.n_cycles, self.width_sigma, self.noise_floor, self.random_peaks, self.true_apex,
+        );
+        println!("  runs={} tol=±{} cycles", self.n, self.tol);
+        println!(
+            "  build : {:>8.2} ms total  ({:.2} us/run)",
+            self.build_ms, build_us
+        );
+        println!(
+            "  score : {:>8.2} ms total  ({:.2} us/run, {:.0} runs/s)",
+            self.score_ms, score_us, throughput
+        );
+        println!("  scorer errors:    {}", self.errors);
+        println!(
+            "  pass1 sensitivity: {:>6.2}%  ({}/{})",
+            pct(self.pass1_hits, self.n),
+            self.pass1_hits,
+            self.n
+        );
+        println!(
+            "  pass2 sensitivity: {:>6.2}%  ({}/{})",
+            pct(self.pass2_hits, self.n),
+            self.pass2_hits,
+            self.n
+        );
+        println!(
+            "  pass2 |apex-truth| cycles: mean={:.2} median={} max={}",
+            mean, median, max
+        );
+
+        let mut buckets = [0usize; 8];
+        for &e in &self.abs_err {
+            buckets[(e.max(0) as usize).min(7)] += 1;
+        }
+        print!("  pass2 err histogram: ");
+        for (i, c) in buckets.iter().enumerate() {
+            let label = if i == 7 { "7+".into() } else { i.to_string() };
+            print!("{label}:{c} ");
+        }
+        println!();
+    }
+}

--- a/rust/apex_sim/src/lib.rs
+++ b/rust/apex_sim/src/lib.rs
@@ -1,0 +1,10 @@
+//! apex_sim library surface: synthetic extraction generation + apex scoring,
+//! reused by the eframe app (`main.rs`) and the `sensitivity` bench example.
+
+#[cfg(feature = "gui")]
+pub mod app;
+pub mod bench;
+#[cfg(feature = "gui")]
+pub mod plots;
+pub mod scorer;
+pub mod sim;

--- a/rust/apex_sim/src/main.rs
+++ b/rust/apex_sim/src/main.rs
@@ -1,0 +1,25 @@
+//! apex_sim -- interactive simulator for the timsseek apex finder.
+//!
+//! Synthesizes extraction products (real co-eluting fragments, contaminants,
+//! noise) with live-tunable knobs, feeds them to the REAL `timsseek` apex
+//! finder, and displays the raw chromatograms, a heatmap, and every per-cycle
+//! intermediate trace with both scoring passes' apexes marked.
+
+use apex_sim::app;
+use eframe::egui;
+
+fn main() -> eframe::Result {
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_inner_size([1400.0, 900.0])
+            .with_min_inner_size([900.0, 600.0])
+            .with_app_id("apex_sim"),
+        ..Default::default()
+    };
+
+    eframe::run_native(
+        "Apex Finder Simulator",
+        options,
+        Box::new(|_cc| Ok(Box::new(app::SimApp::default()))),
+    )
+}

--- a/rust/apex_sim/src/plots.rs
+++ b/rust/apex_sim/src/plots.rs
@@ -1,0 +1,356 @@
+//! egui rendering helpers: chromatogram overlay, heatmap, intermediate traces.
+
+use eframe::egui::{
+    self,
+    Color32,
+    ColorImage,
+    TextureHandle,
+    TextureOptions,
+};
+use egui_plot::{
+    Legend,
+    Line,
+    LineStyle,
+    Plot,
+    PlotPoints,
+};
+
+use crate::scorer::ScoreResult;
+use crate::sim::SimData;
+
+/// Color a transition by its ion series (b/y/a/c/x/z) or unknown (`?`).
+/// Series inferred from the leading char of the label.
+pub fn fragment_type_color(label: &str) -> Color32 {
+    match label.chars().next() {
+        Some('b') => Color32::from_rgb(31, 119, 180),  // blue
+        Some('y') => Color32::from_rgb(214, 39, 40),   // red
+        Some('a') => Color32::from_rgb(23, 190, 207),  // teal
+        Some('c') => Color32::from_rgb(44, 160, 44),   // green
+        Some('x') => Color32::from_rgb(255, 127, 14),  // orange
+        Some('z') => Color32::from_rgb(148, 103, 189), // purple
+        Some('?') => Color32::from_rgb(227, 119, 194), // pink (unknown ion)
+        _ => Color32::from_rgb(160, 160, 160),         // other
+    }
+}
+
+/// Gold, reserved for precursor (M+n) traces.
+const PRECURSOR_COLOR: Color32 = Color32::from_rgb(212, 175, 55);
+
+/// Distinct-ish colors for score traces (bottom panel).
+pub fn palette(idx: usize) -> Color32 {
+    const COLORS: [Color32; 8] = [
+        Color32::from_rgb(31, 119, 180),
+        Color32::from_rgb(255, 127, 14),
+        Color32::from_rgb(44, 160, 44),
+        Color32::from_rgb(214, 39, 40),
+        Color32::from_rgb(148, 103, 189),
+        Color32::from_rgb(140, 86, 75),
+        Color32::from_rgb(227, 119, 194),
+        Color32::from_rgb(23, 190, 207),
+    ];
+    COLORS[idx % COLORS.len()]
+}
+
+fn line_from(name: &str, ys: &[f32]) -> Line<'static> {
+    let pts: PlotPoints = ys
+        .iter()
+        .enumerate()
+        .map(|(x, y)| [x as f64, *y as f64])
+        .collect();
+    Line::new(name.to_owned(), pts)
+}
+
+/// Bright green, reserved for the ground-truth apex.
+const TRUE_APEX_COLOR: Color32 = Color32::from_rgb(0, 230, 90);
+const PASS1_COLOR: Color32 = Color32::GRAY;
+const PASS2_COLOR: Color32 = Color32::from_rgb(255, 80, 80);
+
+/// Draw a vertical marker as a two-point line spanning [0, y_max].
+///
+/// An empty `name` drops the marker from the legend (egui_plot filters empty
+/// names) -- used for the detected-apex markers so the legend stays clean; the
+/// caption above the plot documents their colors.
+fn vmarker(
+    name: &str,
+    x: f64,
+    y_max: f64,
+    color: Color32,
+    style: LineStyle,
+    width: f32,
+) -> Line<'static> {
+    let pts = PlotPoints::new(vec![[x, 0.0], [x, y_max]]);
+    Line::new(name.to_owned(), pts)
+        .color(color)
+        .style(style)
+        .width(width)
+}
+
+/// One-line legend for the vertical apex markers (colored inline).
+pub fn apex_caption(ui: &mut egui::Ui) {
+    ui.horizontal(|ui| {
+        ui.label("apex markers:");
+        ui.colored_label(TRUE_APEX_COLOR, "TRUE (configured)");
+        ui.label("·");
+        ui.colored_label(PASS1_COLOR, "pass1 (quick)");
+        ui.label("·");
+        ui.colored_label(PASS2_COLOR, "pass2 (full)");
+    });
+}
+
+/// Top panel: overlaid chromatograms. Real solid, contaminants dashed,
+/// precursors thicker. Vertical markers: TRUE (green) + pass1/pass2 apexes.
+pub fn chromatograms(
+    ui: &mut egui::Ui,
+    data: &SimData,
+    score: Option<&ScoreResult>,
+    true_apex: f32,
+) {
+    let mut y_max = 1.0_f64;
+    for r in data.fragment_rows.iter().chain(data.precursor_rows.iter()) {
+        for &v in &r.intensities {
+            y_max = y_max.max(v as f64);
+        }
+    }
+
+    Plot::new("chromatograms")
+        .legend(Legend::default())
+        .height(230.0)
+        .include_y(0.0)
+        .show(ui, |pui| {
+            for r in data.fragment_rows.iter() {
+                let mut line =
+                    line_from(&r.label, &r.intensities).color(fragment_type_color(&r.label));
+                // Absent (expected-but-unobserved) transitions drawn dashed.
+                if r.is_absent {
+                    line = line.style(LineStyle::dashed_loose());
+                }
+                pui.line(line);
+            }
+            for r in data.precursor_rows.iter() {
+                let line = line_from(&r.label, &r.intensities)
+                    .color(PRECURSOR_COLOR)
+                    .width(2.5);
+                pui.line(line);
+            }
+            // TRUE apex kept named (green) so it is easy to locate the real
+            // peak; detected apexes get empty names (dropped from legend).
+            pui.line(vmarker(
+                "TRUE apex",
+                true_apex as f64,
+                y_max,
+                TRUE_APEX_COLOR,
+                LineStyle::Solid,
+                2.5,
+            ));
+            if let Some(s) = score {
+                pui.line(vmarker(
+                    "",
+                    s.pass1.apex_cycle as f64,
+                    y_max,
+                    PASS1_COLOR,
+                    LineStyle::dashed_dense(),
+                    2.0,
+                ));
+                pui.line(vmarker(
+                    "",
+                    s.pass2.joint_apex_cycle as f64,
+                    y_max,
+                    PASS2_COLOR,
+                    LineStyle::Solid,
+                    2.0,
+                ));
+            }
+        });
+}
+
+/// Map t in [0,1] to an RGB triple (dark-blue -> cyan -> yellow -> red).
+fn colormap(t: f32) -> [u8; 3] {
+    let t = t.clamp(0.0, 1.0);
+    let (r, g, b) = if t < 0.33 {
+        let u = t / 0.33;
+        (0.0, u * 0.7, 0.3 + u * 0.7)
+    } else if t < 0.66 {
+        let u = (t - 0.33) / 0.33;
+        (u, 0.7 + u * 0.3, 1.0 - u)
+    } else {
+        let u = (t - 0.66) / 0.34;
+        (1.0, 1.0 - u * 0.8, 0.0)
+    };
+    [(r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8]
+}
+
+/// Build a heatmap texture: rows = transitions (fragments), cols = cycles.
+pub fn build_heatmap(ctx: &egui::Context, data: &SimData) -> (TextureHandle, usize) {
+    let rows = &data.fragment_rows;
+    let n_rows = rows.len().max(1);
+    let n_cols = rows
+        .first()
+        .map(|r| r.intensities.len())
+        .unwrap_or(1)
+        .max(1);
+
+    let global_max = rows
+        .iter()
+        .flat_map(|r| r.intensities.iter())
+        .cloned()
+        .fold(0.0_f32, f32::max)
+        .max(1e-6);
+
+    let mut rgb = vec![0u8; n_cols * n_rows * 3];
+    for (y, r) in rows.iter().enumerate() {
+        for (x, &v) in r.intensities.iter().enumerate() {
+            // log-scale for dynamic range
+            let t = ((v / global_max).max(0.0)).powf(0.4);
+            let c = colormap(t);
+            let idx = (y * n_cols + x) * 3;
+            rgb[idx..idx + 3].copy_from_slice(&c);
+        }
+    }
+
+    let image = ColorImage::from_rgb([n_cols, n_rows], &rgb);
+    let tex = ctx.load_texture("heatmap", image, TextureOptions::NEAREST);
+    (tex, n_rows)
+}
+
+/// Middle panel: heatmap image + apex column overlays (TRUE + pass1/pass2).
+pub fn heatmap(
+    ui: &mut egui::Ui,
+    tex: &TextureHandle,
+    n_cols: usize,
+    score: Option<&ScoreResult>,
+    true_apex: f32,
+) {
+    let avail_w = ui.available_width();
+    let height = 150.0;
+    let size = egui::vec2(avail_w, height);
+    let resp = ui.add(
+        egui::Image::new(tex)
+            .fit_to_exact_size(size)
+            .texture_options(TextureOptions::NEAREST),
+    );
+    let rect = resp.rect;
+
+    let painter = ui.painter_at(rect);
+    let col_w = rect.width() / n_cols.max(1) as f32;
+    let x_of = |cycle: f32| rect.left() + (cycle + 0.5) * col_w;
+    painter.vline(
+        x_of(true_apex),
+        rect.y_range(),
+        egui::Stroke::new(2.0, TRUE_APEX_COLOR),
+    );
+    if let Some(s) = score {
+        painter.vline(
+            x_of(s.pass1.apex_cycle as f32),
+            rect.y_range(),
+            egui::Stroke::new(1.5, PASS1_COLOR),
+        );
+        painter.vline(
+            x_of(s.pass2.joint_apex_cycle as f32),
+            rect.y_range(),
+            egui::Stroke::new(2.0, PASS2_COLOR),
+        );
+    }
+}
+
+/// Which intermediate traces to display.
+#[derive(Debug, Clone)]
+pub struct TraceToggles {
+    pub cosine: bool,
+    pub scribe: bool,
+    pub lazyscore: bool,
+    pub log_intensity: bool,
+    pub ms1_precursor: bool,
+    pub apex_profile: bool,
+}
+
+impl Default for TraceToggles {
+    fn default() -> Self {
+        Self {
+            cosine: true,
+            scribe: true,
+            lazyscore: false,
+            log_intensity: false,
+            ms1_precursor: false,
+            apex_profile: true,
+        }
+    }
+}
+
+/// Bottom panel: the apex-finder intermediate traces, min-max normalized to
+/// [0,1] so heterogeneous scales overlay legibly. Apex markers overlaid.
+pub fn traces(ui: &mut egui::Ui, score: &ScoreResult, tog: &TraceToggles, true_apex: f32) {
+    let t = &score.traces;
+    let mut series: Vec<(&str, &[f32])> = Vec::new();
+    if tog.cosine {
+        series.push(("cosine", &t.cosine_trace));
+    }
+    if tog.scribe {
+        series.push(("scribe", &t.ms2_scribe));
+    }
+    if tog.lazyscore {
+        series.push(("lazyscore", &t.ms2_lazyscore));
+    }
+    if tog.log_intensity {
+        series.push(("log_intensity", &t.ms2_log_intensity));
+    }
+    if tog.ms1_precursor {
+        series.push(("ms1_precursor", &t.ms1_precursor_trace));
+    }
+    if tog.apex_profile {
+        series.push(("apex_profile", &t.apex_profile));
+    }
+
+    Plot::new("traces")
+        .legend(Legend::default())
+        .height(230.0)
+        .include_y(0.0)
+        .include_y(1.05)
+        .show(ui, |pui| {
+            for (i, (name, ys)) in series.iter().enumerate() {
+                pui.line(line_from(name, &normalize(ys)).color(palette(i)));
+            }
+            pui.line(vmarker(
+                "TRUE apex",
+                true_apex as f64,
+                1.05,
+                TRUE_APEX_COLOR,
+                LineStyle::Solid,
+                2.5,
+            ));
+            pui.line(vmarker(
+                "",
+                score.pass1.apex_cycle as f64,
+                1.05,
+                PASS1_COLOR,
+                LineStyle::dashed_dense(),
+                2.0,
+            ));
+            pui.line(vmarker(
+                "",
+                score.pass2.joint_apex_cycle as f64,
+                1.05,
+                PASS2_COLOR,
+                LineStyle::Solid,
+                2.0,
+            ));
+        });
+}
+
+/// Min-max normalize to [0,1]; constant series -> zeros.
+fn normalize(ys: &[f32]) -> Vec<f32> {
+    let mut lo = f32::INFINITY;
+    let mut hi = f32::NEG_INFINITY;
+    for &v in ys {
+        if v.is_finite() {
+            lo = lo.min(v);
+            hi = hi.max(v);
+        }
+    }
+    let range = hi - lo;
+    if !range.is_finite() || range <= 0.0 {
+        return vec![0.0; ys.len()];
+    }
+    ys.iter()
+        .map(|&v| ((v - lo) / range).clamp(0.0, 1.0))
+        .collect()
+}

--- a/rust/apex_sim/src/scorer.rs
+++ b/rust/apex_sim/src/scorer.rs
@@ -1,0 +1,126 @@
+//! Thin wrapper over the real `timsseek` apex finder.
+//!
+//! Runs BOTH scoring stages that the production pipeline performs on an
+//! extraction:
+//!   * Pass 1 -- quick apex location (`suggest_apex`), the Phase-1 "prescore".
+//!   * Pass 2 -- full scoring (`score_at`), the Phase-3 calibrated/secondary
+//!     score. Its `joint_apex_cycle` may differ from Pass 1's peak pick.
+//!
+//! No reimplementation: `TraceScorer`, `ElutionTraces`, `ApexLocation` and
+//! `ApexScore` are the exact types the CLI pipeline uses.
+
+use timsseek::scoring::apex_finding::{
+    ApexLocation,
+    ApexScore,
+    ElutionTraces,
+    Extraction,
+    TraceScorer,
+};
+
+/// Everything the UI needs after scoring one synthetic extraction.
+pub struct ScoreResult {
+    /// The per-cycle intermediate traces (cosine/scribe/lazyscore/...).
+    pub traces: ElutionTraces,
+    /// Pass 1: quick apex location (prescore).
+    pub pass1: ApexLocation,
+    /// Pass 2: full scored apex (may sit at a different cycle than pass1).
+    pub pass2: ApexScore,
+}
+
+/// Run the two staged passes on a CALLER-OWNED scorer, returning only the
+/// apex results (no trace clone). This is the allocation-free hot path: reuse
+/// one `TraceScorer` across many extractions, exactly like production's
+/// `ScoringWorker`. Used by the sensitivity bench.
+pub fn run_with(
+    scorer: &mut TraceScorer,
+    extraction: &Extraction<String>,
+    rt_mapper: &dyn Fn(usize) -> u32,
+) -> Result<(ApexLocation, ApexScore), String> {
+    // Stage A: per-cycle traces (resizes the scorer's buffers as needed).
+    scorer
+        .compute_traces(extraction)
+        .map_err(|e| format!("compute_traces failed: {e:?}"))?;
+
+    let cycle_offset = extraction.chromatograms.cycle_offset();
+
+    // Stage B (Pass 1): quick apex suggestion.
+    let pass1 = scorer
+        .suggest_apex(rt_mapper, cycle_offset)
+        .map_err(|e| format!("suggest_apex failed: {e:?}"))?;
+
+    // Stage C (Pass 2): full score at the suggested apex.
+    let pass2 = scorer
+        .score_at(extraction, pass1.apex_cycle, &pass1, rt_mapper)
+        .map_err(|e| format!("score_at failed: {e:?}"))?;
+
+    Ok((pass1, pass2))
+}
+
+/// Run the two staged passes over `extraction`, allocating a fresh scorer and
+/// cloning the traces for display. Convenience for the interactive app.
+///
+/// `rt_mapper` maps a global cycle index to retention time in ms, exactly as
+/// the pipeline supplies it.
+pub fn run(
+    extraction: &Extraction<String>,
+    rt_mapper: &dyn Fn(usize) -> u32,
+) -> Result<ScoreResult, String> {
+    let n_cycles = extraction.chromatograms.num_cycles();
+    let max_frags = extraction.chromatograms.fragments.num_ions().max(1);
+    let mut scorer = TraceScorer::new(n_cycles, max_frags);
+    let (pass1, pass2) = run_with(&mut scorer, extraction, rt_mapper)?;
+    Ok(ScoreResult {
+        traces: scorer.traces().clone(),
+        pass1,
+        pass2,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sim::{
+        SimParams,
+        build,
+    };
+
+    #[test]
+    fn clean_peak_passes_agree() {
+        let mut p = SimParams::default();
+        p.noise_floor = 0.0;
+        p.random_peaks.enabled = false;
+        p.apex_cycle = 30.0;
+        let data = build(&p);
+        let map = p.rt_mapper();
+        let res = run(&data.extraction, &map).unwrap();
+        // apex_profile peak (pass1) must be near the configured apex.
+        assert!((res.pass1.apex_cycle as i64 - 30).abs() <= 2);
+        // pass2 joint apex agrees with pass1 on a clean peak.
+        assert!((res.pass2.joint_apex_cycle as i64 - res.pass1.apex_cycle as i64).abs() <= 3);
+    }
+
+    #[test]
+    fn empty_transition_lowers_score() {
+        // With realistic noise (>0) an absent fragment's row is noise, so it
+        // survives filter_zero_intensity_ions and stays expected -> it should
+        // score lower than the fully-observed case (coverage/cosine penalty).
+        let mut base = SimParams::default();
+        base.noise_floor = 0.1;
+        base.random_peaks.enabled = false;
+        base.apex_cycle = 30.0;
+
+        let clean = build(&base);
+        let map = base.rt_mapper();
+        let clean_score = run(&clean.extraction, &map).unwrap().pass2.score;
+
+        let mut dropped = base.clone();
+        dropped.real_fragments[0].obs_scale = 0.0; // top fragment goes missing
+        let d = build(&dropped);
+        let dropped_score = run(&d.extraction, &map).unwrap().pass2.score;
+
+        assert!(
+            dropped_score < clean_score,
+            "dropped={dropped_score:e} clean={clean_score:e}"
+        );
+    }
+}

--- a/rust/apex_sim/src/sim.rs
+++ b/rust/apex_sim/src/sim.rs
@@ -1,0 +1,473 @@
+//! Synthetic extraction-product generator.
+//!
+//! Builds a [`timsseek::scoring::apex_finding::Extraction`] from tunable knobs
+//! WITHOUT any real timsTOF index or `.d` data. The produced extraction is fed
+//! verbatim to the real `TraceScorer`, so what the app scores is exactly what
+//! the timsseek pipeline would score.
+//!
+//! Model: all "real" fragments co-elute at a single shared apex cycle (no RT
+//! drift between real fragments -- coelution is always real). Realism knobs:
+//! per-fragment noise, theoretical-vs-observed ratio mismatch (`obs_scale`),
+//! absent/empty transitions (`obs_scale == 0`), randomly injected peak-like
+//! objects, and a global noise floor.
+
+use rand::{
+    Rng,
+    SeedableRng,
+};
+use rand_chacha::ChaCha8Rng;
+
+use timsquery::{
+    ChromatogramCollector,
+    MzMajorIntensityArray,
+    TupleRange,
+};
+use timsseek::ExpectedIntensities;
+use timsseek::scoring::apex_finding::Extraction;
+use timsseek::scoring::pipeline::{
+    TOP_N_FRAGMENTS,
+    filter_zero_intensity_ions,
+    select_top_n_fragments,
+};
+
+/// A library fragment. Theoretical and observed intensities are decoupled:
+/// `theo_intensity` is what the spectral library predicts (goes into
+/// `ExpectedIntensities`), while the observed peak height is
+/// `theo_intensity * obs_scale`. Real speclibs are often measured on a
+/// different instrument, so observed ratios rarely match theory exactly.
+///
+/// - `obs_scale == 1.0` -> observed matches theory.
+/// - `obs_scale != 1.0` -> instrument ratio mismatch.
+/// - `obs_scale == 0.0` -> transition is EXPECTED but ABSENT: its trace is
+///   pure noise (an "empty" transition), which stresses fragment coverage.
+#[derive(Debug, Clone)]
+pub struct FragmentSpec {
+    pub label: String,
+    /// Theoretical (library) relative intensity -> `ExpectedIntensities`.
+    pub theo_intensity: f32,
+    /// Observed height multiplier relative to theory (0 => empty/noise-only).
+    pub obs_scale: f32,
+    /// Per-fragment noise multiplier (some fragments noisier than others).
+    pub noise_mult: f32,
+}
+
+/// Random "peak-like objects" injected onto existing transitions/precursors.
+///
+/// These are `count`
+/// gaussian bumps scattered uniformly at random -- each lands on a randomly
+/// chosen existing transition (and optionally precursor) row, at a uniform-
+/// random cycle, with height/width drawn uniformly from the given ranges.
+/// Because they add onto REAL rows, they perturb cosine/scribe/apex directly.
+#[derive(Debug, Clone)]
+pub struct RandomPeaks {
+    pub enabled: bool,
+    pub count: usize,
+    /// Peak height as a fraction of the global `height`, drawn uniformly.
+    pub height_frac_min: f32,
+    pub height_frac_max: f32,
+    /// If true, precursor rows are also eligible targets.
+    pub hit_precursors: bool,
+}
+
+impl Default for RandomPeaks {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            count: 200,
+            height_frac_min: 0.1,
+            height_frac_max: 10.0,
+            hit_precursors: true,
+        }
+    }
+}
+
+/// Full set of simulation knobs. Deterministic given `seed`.
+#[derive(Debug, Clone)]
+pub struct SimParams {
+    pub n_cycles: usize,
+    /// Shared apex position (cycle index) for all real fragments + precursor.
+    pub apex_cycle: f32,
+    /// Elution peak width (gaussian sigma, in cycles).
+    pub width_sigma: f32,
+    /// Global height scale applied on top of each fragment's rel_intensity.
+    pub height: f32,
+
+    pub real_fragments: Vec<FragmentSpec>,
+    pub random_peaks: RandomPeaks,
+
+    /// Number of precursor isotopes (keys 0..n, all positive => scored).
+    pub n_isotopes: usize,
+    pub precursor_intensity: f32,
+
+    /// Global additive noise scale (uniform 0..1 * this, per cell).
+    pub noise_floor: f32,
+
+    pub seed: u64,
+
+    // Cycle <-> ms mapping for the rt_mapper.
+    pub rt_start_ms: u32,
+    pub cycle_period_ms: u32,
+}
+
+impl Default for SimParams {
+    fn default() -> Self {
+        // (label, theo_intensity, obs_scale, noise_mult)
+        // obs_scale defaults deviate from 1.0 => realistic cross-instrument
+        // ratio mismatch out of the box (observed != theoretical).
+        let real_fragments = vec![
+            ("y3", 1.00, 0.9, 1.0),
+            ("y4", 0.80, 1.1, 1.0),
+            ("y5", 0.55, 0.6, 1.5),
+            ("b3", 0.40, 1.3, 1.0),
+            ("b4", 0.30, 0.8, 2.5),
+            ("y6", 0.20, 1.0, 1.0),
+        ]
+        .into_iter()
+        .map(|(l, theo, obs, n)| FragmentSpec {
+            label: l.to_string(),
+            theo_intensity: theo,
+            obs_scale: obs,
+            noise_mult: n,
+        })
+        .collect();
+
+        Self {
+            n_cycles: 60,
+            apex_cycle: 30.0,
+            width_sigma: 1.0,
+            height: 1000.0,
+            real_fragments,
+            random_peaks: RandomPeaks::default(),
+            n_isotopes: 3,
+            precursor_intensity: 0.7,
+            noise_floor: 0.02,
+            seed: 42,
+            rt_start_ms: 60_000,
+            cycle_period_ms: 1_000,
+        }
+    }
+}
+
+impl SimParams {
+    /// Linear cycle -> retention-time (ms) mapper, matching what the pipeline
+    /// passes into `TraceScorer::suggest_apex` / `score_at`.
+    pub fn rt_mapper(&self) -> impl Fn(usize) -> u32 + '_ {
+        move |cycle: usize| self.rt_start_ms + (cycle as u32) * self.cycle_period_ms
+    }
+}
+
+/// A single observed transition row, kept for display alongside the extraction.
+#[derive(Debug, Clone)]
+pub struct TransitionRow {
+    pub label: String,
+    /// True when the transition is expected but observed as noise only
+    /// (`obs_scale == 0`). Drawn dashed so it reads as "missing".
+    pub is_absent: bool,
+    pub intensities: Vec<f32>,
+}
+
+/// The synthesized data: the `Extraction` fed to the scorer, plus the raw rows
+/// (fragments + precursors) kept separately so the UI can plot them directly.
+pub struct SimData {
+    pub extraction: Extraction<String>,
+    pub fragment_rows: Vec<TransitionRow>,
+    pub precursor_rows: Vec<TransitionRow>,
+}
+
+/// Gaussian elution value at `cycle` for a peak centered at `center`.
+fn gaussian(cycle: f32, center: f32, sigma: f32, height: f32) -> f32 {
+    let z = (cycle - center) / sigma;
+    height * (-0.5 * z * z).exp()
+}
+
+/// Build the full synthetic extraction + display rows from `params`.
+pub fn build(params: &SimParams) -> SimData {
+    let mut rng = ChaCha8Rng::seed_from_u64(params.seed);
+    let n = params.n_cycles;
+    let dummy_mz = 500.0_f64;
+
+    // --- Expected intensities: THEORETICAL (library) ratios. ---
+    // These drive cosine/scribe. Observed peaks below may deviate (obs_scale).
+    let expected = ExpectedIntensities::try_from_pairs(
+        params
+            .real_fragments
+            .iter()
+            .map(|f| (f.label.clone(), f.theo_intensity)),
+        (0..params.n_isotopes as i8).map(|iso| {
+            // simple decaying isotope pattern
+            (iso, params.precursor_intensity * 0.6_f32.powi(iso as i32))
+        }),
+    )
+    .expect("labels are unique by construction");
+
+    // --- Fragment rows: OBSERVED = theo * obs_scale (co-eluting). ---
+    let mut frag_order: Vec<(String, f64)> = Vec::new();
+    let mut frag_rows: Vec<TransitionRow> = Vec::new();
+
+    for f in &params.real_fragments {
+        // Observed height decoupled from theory. obs_scale == 0 => absent
+        // transition: no peak, trace is pure noise.
+        let peak = params.height * f.theo_intensity * f.obs_scale;
+        let noise = params.noise_floor * params.height * f.noise_mult;
+        let intensities = (0..n)
+            .map(|c| {
+                let signal = gaussian(c as f32, params.apex_cycle, params.width_sigma, peak);
+                sample_cell(&mut rng, signal, noise)
+            })
+            .collect();
+        frag_order.push((f.label.clone(), dummy_mz));
+        frag_rows.push(TransitionRow {
+            label: f.label.clone(),
+            is_absent: f.obs_scale <= 0.0,
+            intensities,
+        });
+    }
+
+    // --- Precursor rows (isotopes, co-eluting at shared apex) ---
+    let mut prec_order: Vec<(i8, f64)> = Vec::new();
+    let mut prec_rows: Vec<TransitionRow> = Vec::new();
+    for iso in 0..params.n_isotopes as i8 {
+        let peak = params.height * params.precursor_intensity * 0.6_f32.powi(iso as i32);
+        let noise = params.noise_floor * params.height;
+        let intensities = (0..n)
+            .map(|c| {
+                let signal = gaussian(c as f32, params.apex_cycle, params.width_sigma, peak);
+                sample_cell(&mut rng, signal, noise)
+            })
+            .collect();
+        prec_order.push((iso, dummy_mz));
+        prec_rows.push(TransitionRow {
+            label: format!("M+{iso}"),
+            is_absent: false,
+            intensities,
+        });
+    }
+
+    // --- Inject random peak-like objects onto existing rows ---
+    inject_random_peaks(&mut rng, &mut frag_rows, &mut prec_rows, params);
+
+    // --- Pack into MzMajorIntensityArrays (cycle_offset = 0) ---
+    let mut fragments = MzMajorIntensityArray::<String, f32>::try_new_empty(frag_order, n, 0)
+        .expect("non-empty fragments");
+    fill_array(&mut fragments, &frag_rows);
+
+    let mut precursors = MzMajorIntensityArray::<i8, f32>::try_new_empty(prec_order, n, 0)
+        .expect("non-empty precursors");
+    fill_array(&mut precursors, &prec_rows);
+
+    let n_frag_peaks: u64 = frag_rows
+        .iter()
+        .map(|r| r.intensities.iter().filter(|v| **v > 0.0).count() as u64)
+        .sum();
+    let n_prec_peaks: u64 = prec_rows
+        .iter()
+        .map(|r| r.intensities.iter().filter(|v| **v > 0.0).count() as u64)
+        .sum();
+
+    let map = params.rt_mapper();
+    let rt_range_ms =
+        TupleRange::try_new(map(0), map(n - 1)).expect("start < end for positive period");
+
+    let chromatograms = ChromatogramCollector::<String, f32> {
+        id: 0,
+        mobility_ook0: 1.0,
+        rt_seconds: (map((params.apex_cycle as usize).min(n - 1)) as f32) / 1000.0,
+        precursor_mono_mz: dummy_mz,
+        precursor_charge: 2,
+        precursor_mz_limits: (dummy_mz - 1.0, dummy_mz + 1.0),
+        precursors,
+        fragments,
+        rt_range_ms,
+        n_precursor_peaks_added: n_prec_peaks,
+        n_fragment_peaks_added: n_frag_peaks,
+        n_quad_windows_matched: 1,
+    };
+
+    let mut extraction = Extraction {
+        expected_intensities: expected,
+        chromatograms,
+    };
+
+    // Apply the SAME extraction-time filtering the production pipeline always
+    // runs before scoring (broad + calibrated paths, extraction.rs): drop
+    // zero-intensity ions, then keep the top-N fragments by predicted
+    // intensity. Without this the scorer would see rows production discards
+    // (e.g. an absent transition's all-noise row, or >TOP_N_FRAGMENTS ions),
+    // making the sim diverge from what timsseek actually scores.
+    filter_zero_intensity_ions(
+        &mut extraction.chromatograms,
+        &mut extraction.expected_intensities,
+    );
+    select_top_n_fragments(
+        &mut extraction.chromatograms,
+        &mut extraction.expected_intensities,
+        TOP_N_FRAGMENTS,
+    );
+
+    // Display rows are kept RAW (everything simulated), so the plots show the
+    // full input; the scored `extraction` reflects post-filter reality.
+    SimData {
+        extraction,
+        fragment_rows: frag_rows,
+        precursor_rows: prec_rows,
+    }
+}
+
+/// Scatter `count` random gaussian bumps across the transition (and optionally
+/// precursor) rows. Each bump: uniform-random target row, uniform-random center
+/// cycle, uniform height (fraction of global height) and sigma.
+fn inject_random_peaks(
+    rng: &mut ChaCha8Rng,
+    frag_rows: &mut [TransitionRow],
+    prec_rows: &mut [TransitionRow],
+    params: &SimParams,
+) {
+    let rp = &params.random_peaks;
+    if !rp.enabled || rp.count == 0 {
+        return;
+    }
+    let n = params.n_cycles;
+    let n_frag = frag_rows.len();
+    let n_targets = n_frag
+        + if rp.hit_precursors {
+            prec_rows.len()
+        } else {
+            0
+        };
+    if n_targets == 0 {
+        return;
+    }
+
+    for _ in 0..rp.count {
+        let target = rng.random_range(0..n_targets);
+        let row = if target < n_frag {
+            &mut frag_rows[target]
+        } else {
+            &mut prec_rows[target - n_frag]
+        };
+        let center = rng.random_range(0.0..n as f32);
+        // Width inherited from the peptide's elution width (the fragments the
+        // injected peak is contaminating).
+        let sigma = params.width_sigma;
+        let hfrac =
+            rng.random_range(rp.height_frac_min..=rp.height_frac_max.max(rp.height_frac_min));
+        let peak = params.height * hfrac;
+        for (cy, v) in row.intensities.iter_mut().enumerate() {
+            *v += gaussian(cy as f32, center, sigma, peak);
+        }
+    }
+}
+
+/// Sample one observed cell: signal + uniform noise floor, clamped >=0.
+fn sample_cell(rng: &mut ChaCha8Rng, signal: f32, noise: f32) -> f32 {
+    (signal + rng.random::<f32>() * noise).max(0.0)
+}
+
+/// Copy display rows into an [`MzMajorIntensityArray`] via `add_at_index`.
+fn fill_array<K: timsquery::KeyLike>(
+    arr: &mut MzMajorIntensityArray<K, f32>,
+    rows: &[TransitionRow],
+) {
+    // iter_mut_mzs yields rows in mz_order order == `rows` order; zip directly.
+    for (row, ((_key, _mz), mut chrom)) in rows.iter().zip(arr.iter_mut_mzs()) {
+        for (cycle, &val) in row.intensities.iter().enumerate() {
+            if val > 0.0 {
+                chrom.add_at_index(cycle as u32, val);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_peak_apex_lands_at_configured_cycle() {
+        let mut p = SimParams::default();
+        p.noise_floor = 0.0;
+        p.random_peaks.enabled = false;
+        p.apex_cycle = 25.0;
+        let data = build(&p);
+        // The tallest real fragment row should peak at cycle 25.
+        let row = &data.fragment_rows[0];
+        let (max_idx, _) = row
+            .intensities
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .unwrap();
+        assert_eq!(max_idx, 25);
+    }
+
+    #[test]
+    fn deterministic_given_seed() {
+        let p = SimParams::default();
+        let a = build(&p);
+        let b = build(&p);
+        assert_eq!(
+            a.fragment_rows[0].intensities,
+            b.fragment_rows[0].intensities
+        );
+    }
+
+    #[test]
+    fn empty_transition_at_zero_noise_is_filtered_out() {
+        // At zero noise an absent (obs_scale=0) transition is an all-zero row.
+        // Production's filter_zero_intensity_ions drops such rows AND their
+        // expected entry, so the sim must too (matches timsseek exactly).
+        let mut p = SimParams::default();
+        p.noise_floor = 0.0;
+        p.random_peaks.enabled = false;
+        p.real_fragments[0].obs_scale = 0.0;
+        let label = p.real_fragments[0].label.clone();
+        let data = build(&p);
+        // Display keeps the raw simulated row (all zeros, marked absent)...
+        assert!(data.fragment_rows[0].intensities.iter().all(|&v| v == 0.0));
+        assert!(data.fragment_rows[0].is_absent);
+        // ...but it is dropped from the SCORED extraction's expected set.
+        assert!(
+            data.extraction
+                .expected_intensities
+                .get_fragment(&label)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn top_n_fragments_capped_for_scoring() {
+        // Add well beyond TOP_N; the scored extraction caps to TOP_N while
+        // display keeps all raw rows.
+        let mut p = SimParams::default();
+        p.random_peaks.enabled = false;
+        for i in 0..12 {
+            p.real_fragments.push(FragmentSpec {
+                label: format!("z{i}"),
+                theo_intensity: 0.05,
+                obs_scale: 1.0,
+                noise_mult: 1.0,
+            });
+        }
+        let data = build(&p);
+        assert!(data.fragment_rows.len() > 8);
+        assert!(data.extraction.expected_intensities.fragment_len() <= 8);
+    }
+
+    #[test]
+    fn observed_decoupled_from_theoretical() {
+        let mut p = SimParams::default();
+        p.noise_floor = 0.0;
+        p.random_peaks.enabled = false;
+        p.apex_cycle = 30.0;
+        p.real_fragments[0].theo_intensity = 1.0;
+        p.real_fragments[0].obs_scale = 0.5; // observed at half of theory
+        let data = build(&p);
+        let observed_peak = data.fragment_rows[0]
+            .intensities
+            .iter()
+            .cloned()
+            .fold(0.0_f32, f32::max);
+        // Observed peak reflects obs_scale, not the theoretical ratio.
+        assert!((observed_peak - p.height * 0.5).abs() < 1.0);
+    }
+}

--- a/rust/timsseek/src/scoring/pipeline.rs
+++ b/rust/timsseek/src/scoring/pipeline.rs
@@ -229,7 +229,7 @@ impl Default for CalibrationConfig {
 }
 
 /// Number of top fragments to retain for scoring (by predicted intensity).
-const TOP_N_FRAGMENTS: usize = 8;
+pub const TOP_N_FRAGMENTS: usize = 8;
 
 /// Speclib-only pre-gate: reject peptides whose library entry carries no
 /// predicted fragments before doing any extraction work. Shared by the
@@ -247,7 +247,7 @@ fn gate_expected_fragments(item: &QueryItemToScore) -> Result<(), SkipReason> {
 ///
 /// Removes lower-ranked fragments from the chromatogram collector (fragments array + eg)
 /// and from expected intensities, maintaining the invariant that all three agree on count.
-pub(crate) fn select_top_n_fragments<T: KeyLike + Default>(
+pub fn select_top_n_fragments<T: KeyLike + Default>(
     agg: &mut ChromatogramCollector<T, f32>,
     expected: &mut crate::ExpectedIntensities<T>,
     n: usize,
@@ -299,7 +299,7 @@ pub(crate) fn select_top_n_fragments<T: KeyLike + Default>(
     feature = "instrumentation",
     tracing::instrument(skip_all, level = "trace")
 )]
-pub(crate) fn filter_zero_intensity_ions<T: KeyLike + Default>(
+pub fn filter_zero_intensity_ions<T: KeyLike + Default>(
     agg: &mut ChromatogramCollector<T, f32>,
     expected: &mut crate::ExpectedIntensities<T>,
 ) {


### PR DESCRIPTION
New crate rust/apex_sim: an eframe/egui desktop app plus a bench for probing
the timsseek apex finder under synthetic conditions.

What it does
- Synthesizes extraction products (chromatograms) with tunable knobs:
  peak shape, per-fragment noise, theoretical-vs-observed ratio mismatch
  (obs_scale), absent/empty transitions, randomly injected peak-like objects,
  precursor isotopes, global noise floor. Deterministic (seeded ChaCha8Rng).
- Feeds them to the REAL scorer (timsseek TraceScorer / Extraction / traces).
  No scoring is reimplemented; the app runs the two production passes
  (compute_traces -> suggest_apex -> score_at).
- UI: overlaid chromatograms (colored by ion series), transitions-x-cycles
  heatmap, and all intermediate traces (cosine/scribe/lazyscore/log_int/
  ms1/apex_profile) with TRUE / pass1 / pass2 apex markers, plus a full
  ApexScore decomposition (base_score, au/cg terms, 11 features).
- Prints the final SimParams on window close for reproducibility.

Bench (examples/bench.rs, apex_sim::bench)
- Runs a catalog of canonical scenarios (clean, moderate_noise,
  high_noise+interference, heavy_interference, mismatched_library,
  absent_top_fragment) over many seeds and prints per-scenario detail plus
  a comparison summary table (pass1/pass2 sensitivity, median error, us/run).
- Simulation is built up front so it stays OUT of the scoring timer; a single
  TraceScorer is reused across runs (matches production ScoringWorker).

Fidelity
- The sim applies the same filter_zero_intensity_ions +
  select_top_n_fragments(TOP_N_FRAGMENTS) the pipeline runs before scoring,
  so it scores exactly what timsseek would. Those three items are widened to
  pub in timsseek (only visibility, no behavior change).

Build / CI
- egui/eframe/egui_plot gated behind a default-on 'gui' feature; the bench
  builds lean with --no-default-features (no egui/winit in CI).
- .github/workflows/apex_bench.yml runs the bench (--no-default-features) on
  PRs touching apex_sim/timsseek and upserts a sticky results comment.

Validation
- cargo test -p apex_sim (7 pass), and under --no-default-features (7 pass).
- cargo build -p apex_sim (gui) and --no-default-features both clean.
- Ran the bench locally; example sticky-comment output is the summary table.
- Reviewed by a second pass (senior-eng); the two fidelity/methodology
  findings (production filtering + reused-scorer timing) are applied here.