### PR TITLE
apex: clean apex-profile weighting (bench-validated, perf-optimized)

### DIFF
--- a/rust/apex_sim/src/bench.rs
+++ b/rust/apex_sim/src/bench.rs
@@ -94,6 +94,13 @@ pub fn canonical_suite() -> Vec<(&'static str, SimParams)> {
     absent.random_peaks.count = 100;
     absent.real_fragments[0].obs_scale = 0.0;
 
+    // Absent precursor at stress level: MS1 precursor undetected (intensity 0),
+    // fragments intact. Guards against over-reliance on precursor signal.
+    let mut absent_prec = base();
+    absent_prec.noise_floor = 0.5;
+    absent_prec.random_peaks.count = 100;
+    absent_prec.precursor_intensity = 0.0;
+
     vec![
         ("clean", clean),
         ("moderate_noise", moderate),
@@ -101,6 +108,7 @@ pub fn canonical_suite() -> Vec<(&'static str, SimParams)> {
         ("heavy_interference", heavy),
         ("mismatched_library", mismatched),
         ("absent_top_fragment", absent),
+        ("absent_precursor", absent_prec),
     ]
 }
 

--- a/rust/timsseek/src/scoring/apex/coelution.rs
+++ b/rust/timsseek/src/scoring/apex/coelution.rs
@@ -1,0 +1,193 @@
+//! Ratio-free temporal-coelution weighting.
+//!
+//! For each cycle, over a +/-W window, each active fragment's XIC slice is
+//! centered and normalized to a unit vector. The coelution score is the
+//! expected-intensity-weighted mean pairwise correlation of those unit
+//! vectors. Because slices are centered+normalized, the score is independent
+//! of absolute fragment ratios: it rewards genuine co-eluting peaks and
+//! suppresses uncorrelated random-interferent pileups.
+//! `profile[t] *= 1 + K * max(coel, 0)`. Disabled when K<=0.
+
+use super::{
+    ApexConfig,
+    ApexScratch,
+    Rows,
+};
+
+/// Multiply `profile` in place by the coelution weight. `rows` are the active
+/// fragment rows (see [`super::active_rows`]).
+pub(crate) fn weight(
+    profile: &mut [f32],
+    rows: &Rows<'_>,
+    cfg: &ApexConfig,
+    scratch: &mut ApexScratch,
+) {
+    let k = cfg.coel_k;
+    if k <= 0.0 || profile.is_empty() || rows.len() < 2 {
+        return;
+    }
+    let w = cfg.coel_w.max(1.0) as usize;
+    kernel(profile, rows, w, k, scratch);
+}
+
+/// Pure numeric core, decoupled from the extraction data model for testing.
+fn kernel(profile: &mut [f32], rows: &Rows<'_>, w: usize, k: f32, scratch: &mut ApexScratch) {
+    let n = profile.len();
+    let win = 2 * w + 1;
+    let ApexScratch {
+        cn, active, wacc, ..
+    } = scratch;
+    cn.clear();
+    cn.resize(rows.len() * win, 0.0);
+    wacc.clear();
+    wacc.resize(win, 0.0);
+
+    for t in 0..n {
+        // The weight only ever multiplies profile[t]; a zero cycle stays zero
+        // for any coel, so skip its O(rows*win) window work.
+        if profile[t] == 0.0 {
+            continue;
+        }
+
+        let lo = t.saturating_sub(w);
+        let hi = (t + w + 1).min(n);
+        let wl = hi - lo;
+        active.clear();
+
+        for (fi, (chrom, _wt)) in rows.iter().enumerate() {
+            let slice = &chrom[lo..hi];
+            let mean: f32 = slice.iter().sum::<f32>() / wl as f32;
+            let base = fi * win;
+            let mut nsq = 0.0f32;
+            for j in 0..wl {
+                let v = slice[j] - mean;
+                cn[base + j] = v;
+                nsq += v * v;
+            }
+            let norm = nsq.sqrt();
+            if norm > 1e-12 {
+                for j in 0..wl {
+                    cn[base + j] /= norm;
+                }
+                active.push(fi);
+            }
+        }
+
+        // Expected-intensity-weighted mean pairwise correlation, computed in
+        // O(active) rather than O(active^2): for unit vectors u_a,
+        //   sum_{a<b} w_a w_b <u_a,u_b> = (||W||^2 - sum w_a^2) / 2,
+        //   sum_{a<b} w_a w_b          = ((sum w_a)^2 - sum w_a^2) / 2,
+        // where W = sum_a w_a u_a. The /2 cancels in the ratio.
+        wacc[..wl].fill(0.0);
+        let mut sw = 0.0f32;
+        let mut sw2 = 0.0f32;
+        for &fi in active.iter() {
+            let base = fi * win;
+            let wa = rows[fi].1;
+            sw += wa;
+            sw2 += wa * wa;
+            for j in 0..wl {
+                wacc[j] += wa * cn[base + j];
+            }
+        }
+        let mut wnorm2 = 0.0f32;
+        for &x in &wacc[..wl] {
+            wnorm2 += x * x;
+        }
+        let den = sw * sw - sw2;
+        let coel = if den > 0.0 {
+            ((wnorm2 - sw2) / den).max(0.0)
+        } else {
+            0.0
+        };
+        profile[t] *= 1.0 + k * coel;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Gaussian bump centered at `c` over `n` cycles.
+    fn bump(n: usize, c: usize) -> Vec<f32> {
+        (0..n)
+            .map(|t| {
+                let d = t as f32 - c as f32;
+                (-(d * d) / 2.0).exp()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn coelution_rewards_coeluting_over_scattered() {
+        let n = 11;
+        let cfg = ApexConfig {
+            coel_k: 1.0,
+            coel_w: 2.0,
+            ..Default::default()
+        };
+        let mut scratch = ApexScratch::default();
+
+        // Co-eluting: three fragments all peaking at cycle 5.
+        let (a, b, c) = (bump(n, 5), bump(n, 5), bump(n, 5));
+        let rows_coel: Rows = vec![
+            (a.as_slice(), 1.0),
+            (b.as_slice(), 1.0),
+            (c.as_slice(), 1.0),
+        ];
+        let mut p_coel = vec![1.0f32; n];
+        weight(&mut p_coel, &rows_coel, &cfg, &mut scratch);
+
+        // Scattered: three fragments peaking at different cycles.
+        let (d, e, f) = (bump(n, 3), bump(n, 5), bump(n, 7));
+        let rows_scat: Rows = vec![
+            (d.as_slice(), 1.0),
+            (e.as_slice(), 1.0),
+            (f.as_slice(), 1.0),
+        ];
+        let mut p_scat = vec![1.0f32; n];
+        weight(&mut p_scat, &rows_scat, &cfg, &mut scratch);
+
+        // The apex of genuinely co-eluting fragments is boosted...
+        assert!(
+            p_coel[5] > 1.0,
+            "co-eluting apex must be up-weighted: {}",
+            p_coel[5]
+        );
+        // ...and more than a scattered pileup at the same cycle.
+        assert!(
+            p_coel[5] > p_scat[5],
+            "co-eluting {} should beat scattered {}",
+            p_coel[5],
+            p_scat[5]
+        );
+    }
+
+    #[test]
+    fn coelution_noop_when_disabled_or_too_few_rows() {
+        let n = 7;
+        let mut scratch = ApexScratch::default();
+        let a = bump(n, 3);
+        let b = bump(n, 3);
+
+        // Disabled (k = 0).
+        let cfg_off = ApexConfig {
+            coel_k: 0.0,
+            ..Default::default()
+        };
+        let rows: Rows = vec![(a.as_slice(), 1.0), (b.as_slice(), 1.0)];
+        let mut p = vec![1.0f32; n];
+        weight(&mut p, &rows, &cfg_off, &mut scratch);
+        assert!(p.iter().all(|&x| x == 1.0));
+
+        // Fewer than two rows: nothing to correlate.
+        let cfg_on = ApexConfig {
+            coel_k: 1.0,
+            ..Default::default()
+        };
+        let rows_one: Rows = vec![(a.as_slice(), 1.0)];
+        let mut p2 = vec![1.0f32; n];
+        weight(&mut p2, &rows_one, &cfg_on, &mut scratch);
+        assert!(p2.iter().all(|&x| x == 1.0));
+    }
+}

--- a/rust/timsseek/src/scoring/apex/coelution.rs
+++ b/rust/timsseek/src/scoring/apex/coelution.rs
@@ -42,10 +42,10 @@ fn kernel(profile: &mut [f32], rows: &Rows<'_>, w: usize, k: f32, scratch: &mut 
     wacc.clear();
     wacc.resize(win, 0.0);
 
-    for t in 0..n {
+    for (t, p) in profile.iter_mut().enumerate() {
         // The weight only ever multiplies profile[t]; a zero cycle stays zero
         // for any coel, so skip its O(rows*win) window work.
-        if profile[t] == 0.0 {
+        if *p == 0.0 {
             continue;
         }
 
@@ -100,7 +100,7 @@ fn kernel(profile: &mut [f32], rows: &Rows<'_>, w: usize, k: f32, scratch: &mut 
         } else {
             0.0
         };
-        profile[t] *= 1.0 + k * coel;
+        *p *= 1.0 + k * coel;
     }
 }
 

--- a/rust/timsseek/src/scoring/apex/mod.rs
+++ b/rust/timsseek/src/scoring/apex/mod.rs
@@ -1,0 +1,112 @@
+//! Optional per-cycle weighting passes applied to the composite apex profile
+//! before peak-picking.
+//!
+//! The base profile (`cos^p * I^q * (s_ratio + s_norm)`, optionally blurred)
+//! is built in [`crate::scoring::apex_finding`]. The passes here multiply that
+//! profile in place: each rewards genuine multi-signal coincidence at a cycle
+//! and suppresses random-interferent pileups, without depending on absolute
+//! fragment ratios. All knobs and their shipping defaults are bench-validated
+//! on the `apex_sim` canonical suite (see [`ApexConfig`]).
+
+use crate::scoring::apex_finding::Extraction;
+use timsquery::traits::KeyLike;
+
+mod coelution;
+mod vote;
+
+/// Tunable apex-profile knobs. `Default` holds the bench-validated shipping
+/// values. Ablation flips individual fields; shipped values live in `Default`.
+#[derive(Debug, Clone)]
+pub struct ApexConfig {
+    /// Cosine exponent in the base profile: `cos^cos_pow`.
+    pub cos_pow: f32,
+    /// Log-intensity exponent in the base profile: `I^i_exp`.
+    pub i_exp: f32,
+    /// Additive scribe floor: `apex = C * (s_ratio + s_norm)`.
+    pub s_ratio: f32,
+    /// Gaussian-blur passes applied to the base profile (0 = none).
+    pub blur_passes: usize,
+    /// Joint-apex snap window: use joint apex if within this many cycles.
+    pub joint_snap: usize,
+    /// Ratio-free coelution weight strength (0 = disabled).
+    pub coel_k: f32,
+    /// Coelution correlation half-window (cycles).
+    pub coel_w: f32,
+    /// Cross-row coincidence-vote weight strength (0 = disabled).
+    pub vote_k: f32,
+    /// Vote sigmoid threshold (z-score units).
+    pub vote_tau: f32,
+    /// Vote sigmoid softness (z-score units).
+    pub vote_s: f32,
+}
+
+impl Default for ApexConfig {
+    fn default() -> Self {
+        Self {
+            cos_pow: 0.5,
+            i_exp: 0.75,
+            s_ratio: 1.75,
+            blur_passes: 1,
+            joint_snap: 1,
+            coel_k: 1.04,
+            coel_w: 2.0,
+            vote_k: 14.43,
+            vote_tau: 1.28,
+            vote_s: 0.42,
+        }
+    }
+}
+
+/// Reusable per-worker scratch for the weight passes. Owned by the scorer and
+/// reused across candidates so the hot loop never allocates.
+#[derive(Debug, Default)]
+pub struct ApexScratch {
+    /// Coelution: centered+normalized windows, row-major `[frag * win + j]`.
+    cn: Vec<f32>,
+    /// Coelution: indices of fragments with non-degenerate windows this cycle.
+    active: Vec<usize>,
+    /// Coelution: weighted sum of active unit-window vectors.
+    wacc: Vec<f32>,
+    /// Vote: per-cycle accumulated support across rows.
+    support: Vec<f32>,
+    /// Vote: baseline-subtracted, clipped row.
+    r: Vec<f32>,
+    /// Vote: matched-filtered row.
+    m: Vec<f32>,
+    /// Vote: selection buffer for median/MAD.
+    tmp: Vec<f32>,
+}
+
+/// Active fragment rows: `(per-cycle XIC slice, expected-intensity weight)`.
+/// Only fragments with positive expected intensity participate.
+pub(crate) type Rows<'a> = Vec<(&'a [f32], f32)>;
+
+/// Collect the active fragment rows from an extraction.
+pub(crate) fn active_rows<'a, T: KeyLike>(ctx: &'a Extraction<T>) -> Rows<'a> {
+    let mut rows: Rows<'a> = Vec::new();
+    for ((key, _mz), chrom) in ctx.chromatograms.fragments.iter_mzs() {
+        let exp = ctx.expected_intensities.get_fragment(key).unwrap_or(0.0);
+        if exp > 0.0 {
+            rows.push((chrom, exp));
+        }
+    }
+    rows
+}
+
+/// Apply the enabled weight passes to `profile` in place, in order.
+pub(crate) fn weight_profile<T: KeyLike>(
+    profile: &mut [f32],
+    ctx: &Extraction<T>,
+    cfg: &ApexConfig,
+    scratch: &mut ApexScratch,
+) {
+    if profile.is_empty() {
+        return;
+    }
+    if cfg.coel_k <= 0.0 && cfg.vote_k <= 0.0 {
+        return;
+    }
+    let rows = active_rows(ctx);
+    coelution::weight(profile, &rows, cfg, scratch);
+    vote::weight(profile, &rows, cfg, scratch);
+}

--- a/rust/timsseek/src/scoring/apex/mod.rs
+++ b/rust/timsseek/src/scoring/apex/mod.rs
@@ -48,11 +48,11 @@ impl Default for ApexConfig {
             s_ratio: 1.75,
             blur_passes: 1,
             joint_snap: 1,
-            coel_k: 1.04,
+            coel_k: 1.0,
             coel_w: 2.0,
-            vote_k: 14.43,
-            vote_tau: 1.28,
-            vote_s: 0.42,
+            vote_k: 14.0,
+            vote_tau: 1.3,
+            vote_s: 0.4,
         }
     }
 }

--- a/rust/timsseek/src/scoring/apex/vote.rs
+++ b/rust/timsseek/src/scoring/apex/vote.rs
@@ -75,7 +75,7 @@ fn kernel(
         }
 
         // Matched filter (edge-clamped convolution with G).
-        for t in 0..n {
+        for (t, mt) in m.iter_mut().enumerate() {
             let mut acc = 0.0f32;
             for (di, &g) in G.iter().enumerate() {
                 let idx = t as isize + di as isize - 2;
@@ -83,7 +83,7 @@ fn kernel(
                     acc += g * r[idx as usize];
                 }
             }
-            m[t] = acc / gsum;
+            *mt = acc / gsum;
         }
 
         // Robust scale: MAD of m (both medians via O(n) selection).

--- a/rust/timsseek/src/scoring/apex/vote.rs
+++ b/rust/timsseek/src/scoring/apex/vote.rs
@@ -1,0 +1,186 @@
+//! Cross-row coincidence-voting weighting.
+//!
+//! Per fragment row: subtract the row's global median (baseline), clip to >=0,
+//! matched-filter with the known gaussian (sigma~1), then convert to a robust
+//! soft vote `v = sigmoid((z - tau)/s)` where `z = (m - median(m))/MAD`. Votes
+//! are summed across rows (expected-intensity weighted) into a support trace;
+//! `profile[t] *= 1 + K * support_norm(t)`. Because interferents are
+//! independent across rows, only a genuine apex gets many concurrent votes; a
+//! vote saturates so a 10x-tall interferent counts the same as a real peak.
+//! Disabled when K<=0.
+
+use super::{
+    ApexConfig,
+    ApexScratch,
+    Rows,
+};
+
+/// Gaussian matched-filter kernel (sigma~1), 5-tap.
+const G: [f32; 5] = [0.13534, 0.60653, 1.0, 0.60653, 0.13534];
+
+/// Multiply `profile` in place by the coincidence-vote weight. `rows` are the
+/// active fragment rows (see [`super::active_rows`]).
+pub(crate) fn weight(
+    profile: &mut [f32],
+    rows: &Rows<'_>,
+    cfg: &ApexConfig,
+    scratch: &mut ApexScratch,
+) {
+    let vk = cfg.vote_k;
+    if vk <= 0.0 || profile.is_empty() || rows.is_empty() {
+        return;
+    }
+    kernel(
+        profile,
+        rows,
+        cfg.vote_tau,
+        cfg.vote_s.max(1e-3),
+        vk,
+        scratch,
+    );
+}
+
+/// Pure numeric core, decoupled from the extraction data model for testing.
+fn kernel(
+    profile: &mut [f32],
+    rows: &Rows<'_>,
+    tau: f32,
+    soft: f32,
+    vk: f32,
+    scratch: &mut ApexScratch,
+) {
+    let n = profile.len();
+    let gsum: f32 = G.iter().sum();
+
+    // `support` must start zeroed (accumulated across rows); r/m/tmp are fully
+    // overwritten per row.
+    let ApexScratch {
+        support, r, m, tmp, ..
+    } = scratch;
+    support.clear();
+    support.resize(n, 0.0);
+    r.resize(n, 0.0);
+    m.resize(n, 0.0);
+    tmp.clear();
+    let mut wsum = 0.0f32;
+
+    for &(chrom, w) in rows.iter() {
+        // Baseline = global median of the row. select_nth is O(n) vs
+        // O(n log n) for a full sort; only the k-th order statistic is needed.
+        tmp.clear();
+        tmp.extend_from_slice(chrom);
+        let med = *tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1;
+        for t in 0..n {
+            r[t] = (chrom[t] - med).max(0.0);
+        }
+
+        // Matched filter (edge-clamped convolution with G).
+        for t in 0..n {
+            let mut acc = 0.0f32;
+            for (di, &g) in G.iter().enumerate() {
+                let idx = t as isize + di as isize - 2;
+                if idx >= 0 && (idx as usize) < n {
+                    acc += g * r[idx as usize];
+                }
+            }
+            m[t] = acc / gsum;
+        }
+
+        // Robust scale: MAD of m (both medians via O(n) selection).
+        tmp.clear();
+        tmp.extend_from_slice(m.as_slice());
+        let mmed = *tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1;
+        for t in 0..n {
+            tmp[t] = (m[t] - mmed).abs();
+        }
+        let mad = (*tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1).max(1e-6);
+
+        // Soft vote per cycle.
+        for t in 0..n {
+            let z = (m[t] - mmed) / mad;
+            let v = 1.0 / (1.0 + (-(z - tau) / soft).exp());
+            support[t] += w * v;
+        }
+        wsum += w;
+    }
+
+    if wsum <= 0.0 {
+        return;
+    }
+    for t in 0..n {
+        profile[t] *= 1.0 + vk * support[t] / wsum;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bump(n: usize, c: usize, height: f32) -> Vec<f32> {
+        (0..n)
+            .map(|t| {
+                let d = t as f32 - c as f32;
+                height * (-(d * d) / 2.0).exp()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn many_concurrent_votes_beat_one_tall_interferent() {
+        let n = 11;
+        let cfg = ApexConfig {
+            vote_k: 10.0,
+            vote_tau: 1.28,
+            vote_s: 0.42,
+            ..Default::default()
+        };
+        let mut scratch = ApexScratch::default();
+
+        // Five fragments each with a modest coincident peak at cycle 5.
+        let cols: Vec<Vec<f32>> = (0..5).map(|_| bump(n, 5, 1.0)).collect();
+        let rows_many: Rows = cols.iter().map(|c| (c.as_slice(), 1.0)).collect();
+        let mut p_many = vec![1.0f32; n];
+        weight(&mut p_many, &rows_many, &cfg, &mut scratch);
+
+        // One single 10x-tall interferent peak, four flat rows.
+        let tall = bump(n, 5, 10.0);
+        let flat = vec![0.0f32; n];
+        let rows_one: Rows = vec![
+            (tall.as_slice(), 1.0),
+            (flat.as_slice(), 1.0),
+            (flat.as_slice(), 1.0),
+            (flat.as_slice(), 1.0),
+            (flat.as_slice(), 1.0),
+        ];
+        let mut p_one = vec![1.0f32; n];
+        weight(&mut p_one, &rows_one, &cfg, &mut scratch);
+
+        // Concurrent multi-fragment support wins over a lone tall interferent.
+        assert!(
+            p_many[5] > 1.0,
+            "coincident apex must be up-weighted: {}",
+            p_many[5]
+        );
+        assert!(
+            p_many[5] > p_one[5],
+            "5 concurrent votes {} should beat 1 tall interferent {}",
+            p_many[5],
+            p_one[5]
+        );
+    }
+
+    #[test]
+    fn vote_noop_when_disabled() {
+        let n = 7;
+        let cfg = ApexConfig {
+            vote_k: 0.0,
+            ..Default::default()
+        };
+        let mut scratch = ApexScratch::default();
+        let c = bump(n, 3, 1.0);
+        let rows: Rows = vec![(c.as_slice(), 1.0)];
+        let mut p = vec![1.0f32; n];
+        weight(&mut p, &rows, &cfg, &mut scratch);
+        assert!(p.iter().all(|&x| x == 1.0));
+    }
+}

--- a/rust/timsseek/src/scoring/apex_finding.rs
+++ b/rust/timsseek/src/scoring/apex_finding.rs
@@ -301,11 +301,11 @@ pub struct ApexConfig {
 impl Default for ApexConfig {
     fn default() -> Self {
         Self {
-            cos_pow: 3.0,
-            i_exp: 1.0,
-            s_ratio: 0.5,
-            blur_passes: 0,
-            joint_snap: 3,
+            cos_pow: 0.5,
+            i_exp: 0.75,
+            s_ratio: 1.75,
+            blur_passes: 1,
+            joint_snap: 1,
         }
     }
 }

--- a/rust/timsseek/src/scoring/apex_finding.rs
+++ b/rust/timsseek/src/scoring/apex_finding.rs
@@ -846,8 +846,16 @@ impl TraceScorer {
         // Centered+normalized window per fragment, row-major [frag * win + j].
         let mut cn: Vec<f32> = vec![0.0; rows.len() * win];
         let mut active: Vec<usize> = Vec::with_capacity(rows.len());
+        // Weighted sum of active unit-window vectors (reused per cycle).
+        let mut wacc: Vec<f32> = vec![0.0; win];
 
         for t in 0..n {
+            // The weight only ever multiplies apex_profile[t]; a zero cycle
+            // stays zero for any coel, so skip its O(rows*win) window work.
+            if self.traces.apex_profile[t] == 0.0 {
+                continue;
+            }
+
             let lo = t.saturating_sub(w);
             let hi = (t + w + 1).min(n);
             let wl = hi - lo;
@@ -872,26 +880,34 @@ impl TraceScorer {
                 }
             }
 
-            let mut num = 0.0f32;
-            let mut den = 0.0f32;
-            for a in 0..active.len() {
-                let ia = active[a];
-                let ba = ia * win;
-                let wa = rows[ia].1;
-                for b in (a + 1)..active.len() {
-                    let ib = active[b];
-                    let bb = ib * win;
-                    let ww = wa * rows[ib].1;
-                    let mut corr = 0.0f32;
-                    for j in 0..wl {
-                        corr += cn[ba + j] * cn[bb + j];
-                    }
-                    num += ww * corr;
-                    den += ww;
+            // Expected-intensity-weighted mean pairwise correlation, computed
+            // in O(active) rather than O(active^2): for unit vectors u_a,
+            //   sum_{a<b} w_a w_b <u_a,u_b> = (||W||^2 - sum w_a^2) / 2,
+            //   sum_{a<b} w_a w_b          = ((sum w_a)^2 - sum w_a^2) / 2,
+            // where W = sum_a w_a u_a. The /2 cancels in the ratio.
+            wacc[..wl].fill(0.0);
+            let mut sw = 0.0f32;
+            let mut sw2 = 0.0f32;
+            for &fi in &active {
+                let base = fi * win;
+                let wa = rows[fi].1;
+                sw += wa;
+                sw2 += wa * wa;
+                for j in 0..wl {
+                    wacc[j] += wa * cn[base + j];
                 }
             }
-            let coel = if den > 0.0 { num / den } else { 0.0 };
-            self.traces.apex_profile[t] *= 1.0 + k * coel.max(0.0);
+            let mut wnorm2 = 0.0f32;
+            for &x in &wacc[..wl] {
+                wnorm2 += x * x;
+            }
+            let den = sw * sw - sw2;
+            let coel = if den > 0.0 {
+                ((wnorm2 - sw2) / den).max(0.0)
+            } else {
+                0.0
+            };
+            self.traces.apex_profile[t] *= 1.0 + k * coel;
         }
     }
 

--- a/rust/timsseek/src/scoring/apex_finding.rs
+++ b/rust/timsseek/src/scoring/apex_finding.rs
@@ -27,6 +27,11 @@
 
 use std::fmt::Display;
 
+use super::apex::{
+    ApexConfig,
+    ApexScratch,
+    weight_profile,
+};
 use super::{
     NUM_MS1_IONS,
     NUM_MS2_IONS,
@@ -280,70 +285,6 @@ impl ElutionTraces {
     }
 }
 
-/// Tunable apex-profile knobs. `Default` holds the bench-validated shipping
-/// values (see the apex_sim canonical suite). Ablation flips individual fields;
-/// shipped values live in `Default`.
-#[derive(Debug, Clone)]
-pub struct ApexConfig {
-    /// Cosine exponent in the base profile: `cos^cos_pow`.
-    pub cos_pow: f32,
-    /// Log-intensity exponent in the base profile: `I^i_exp`.
-    pub i_exp: f32,
-    /// Additive scribe floor: `apex = C * (s_ratio + s_norm)`.
-    pub s_ratio: f32,
-    /// Gaussian-blur passes applied to the base profile (0 = none).
-    pub blur_passes: usize,
-    /// Joint-apex snap window: use joint apex if within this many cycles.
-    pub joint_snap: usize,
-    /// Ratio-free coelution weight strength (0 = disabled).
-    pub coel_k: f32,
-    /// Coelution correlation half-window (cycles).
-    pub coel_w: f32,
-    /// Cross-row coincidence-vote weight strength (0 = disabled).
-    pub vote_k: f32,
-    /// Vote sigmoid threshold (z-score units).
-    pub vote_tau: f32,
-    /// Vote sigmoid softness (z-score units).
-    pub vote_s: f32,
-}
-
-impl Default for ApexConfig {
-    fn default() -> Self {
-        Self {
-            cos_pow: 0.5,
-            i_exp: 0.75,
-            s_ratio: 1.75,
-            blur_passes: 1,
-            joint_snap: 1,
-            coel_k: 1.04,
-            coel_w: 2.0,
-            vote_k: 14.43,
-            vote_tau: 1.28,
-            vote_s: 0.42,
-        }
-    }
-}
-
-/// Reusable per-worker scratch for the apex-profile weight passes. Owned by
-/// `TraceScorer` and reused across candidates so the hot loop never allocates.
-#[derive(Debug, Default)]
-struct ApexScratch {
-    /// Coelution: centered+normalized windows, row-major `[frag * win + j]`.
-    cn: Vec<f32>,
-    /// Coelution: indices of fragments with non-degenerate windows this cycle.
-    active: Vec<usize>,
-    /// Coelution: weighted sum of active unit-window vectors.
-    wacc: Vec<f32>,
-    /// Vote: per-cycle accumulated support across rows.
-    support: Vec<f32>,
-    /// Vote: baseline-subtracted, clipped row.
-    r: Vec<f32>,
-    /// Vote: matched-filtered row.
-    m: Vec<f32>,
-    /// Vote: selection buffer for median/MAD.
-    tmp: Vec<f32>,
-}
-
 /// The core engine for finding peptide apexes.
 #[derive(Debug)]
 pub struct TraceScorer {
@@ -450,8 +391,12 @@ impl TraceScorer {
 
         self.compute_pass_1(scoring_ctx)?;
         self.compute_main_score_trace();
-        self.apply_coelution_weighting(scoring_ctx);
-        self.apply_vote_weighting(scoring_ctx);
+        weight_profile(
+            &mut self.traces.apex_profile,
+            scoring_ctx,
+            &self.cfg,
+            &mut self.apex_scratch,
+        );
         self.build_profiles_cached();
 
         Ok(())
@@ -537,13 +482,12 @@ impl TraceScorer {
 
         // Joint apex: find precursor-fragment agreement, but use clicked cycle if far from it
         let joint_apex = find_joint_apex(&self.cosine_profile, &self.traces.ms1_precursor_trace);
-        let effective_apex = if (joint_apex as i64 - cycle as i64).unsigned_abs() as usize
-            <= self.cfg.joint_snap
-        {
-            joint_apex
-        } else {
-            cycle
-        };
+        let effective_apex =
+            if (joint_apex as i64 - cycle as i64).unsigned_abs() as usize <= self.cfg.joint_snap {
+                joint_apex
+            } else {
+                cycle
+            };
 
         // 11 features at effective apex
         let n_cycles = self.cosine_profile.len();
@@ -821,228 +765,13 @@ impl TraceScorer {
                 0.5 // Degrade to cosine-only when scribe is constant
             };
 
-            self.traces.apex_profile.push(c * (self.cfg.s_ratio + s_norm));
+            self.traces
+                .apex_profile
+                .push(c * (self.cfg.s_ratio + s_norm));
         }
 
         for _ in 0..self.cfg.blur_passes {
             gaussblur_in_place(&mut self.traces.apex_profile);
-        }
-    }
-
-    /// Per-cycle ratio-free coelution weighting of the apex profile.
-    ///
-    /// For each cycle, over a +/-W window, center-normalizes each active
-    /// fragment's XIC slice and takes the expected-intensity-weighted mean
-    /// pairwise correlation. Because slices are centered+normalized, this is
-    /// independent of absolute fragment ratios: it rewards genuine co-eluting
-    /// peaks and suppresses uncorrelated random-interferent pileups.
-    /// `apex_profile[t] *= 1 + K * max(coel, 0)`. Disabled when K<=0.
-    fn apply_coelution_weighting<T: KeyLike>(&mut self, scoring_ctx: &Extraction<T>) {
-        let Self {
-            traces,
-            apex_scratch,
-            cfg,
-            ..
-        } = self;
-        let k = cfg.coel_k;
-        if k <= 0.0 {
-            return;
-        }
-        let w = cfg.coel_w.max(1.0) as usize;
-        let collector = &scoring_ctx.chromatograms;
-        let n = traces.apex_profile.len();
-        if n == 0 {
-            return;
-        }
-
-        // Active fragments: (per-cycle slice, expected-intensity weight).
-        let mut rows: Vec<(&[f32], f32)> = Vec::new();
-        for ((key, _mz), chrom) in collector.fragments.iter_mzs() {
-            let exp = scoring_ctx
-                .expected_intensities
-                .get_fragment(key)
-                .unwrap_or(0.0);
-            if exp > 0.0 {
-                rows.push((chrom, exp));
-            }
-        }
-        if rows.len() < 2 {
-            return;
-        }
-
-        let win = 2 * w + 1;
-        // Reused scratch: centered+normalized windows [frag * win + j], the
-        // active-fragment index list, and the weighted window-sum vector.
-        let ApexScratch {
-            cn, active, wacc, ..
-        } = apex_scratch;
-        cn.clear();
-        cn.resize(rows.len() * win, 0.0);
-        wacc.clear();
-        wacc.resize(win, 0.0);
-
-        for t in 0..n {
-            // The weight only ever multiplies apex_profile[t]; a zero cycle
-            // stays zero for any coel, so skip its O(rows*win) window work.
-            if traces.apex_profile[t] == 0.0 {
-                continue;
-            }
-
-            let lo = t.saturating_sub(w);
-            let hi = (t + w + 1).min(n);
-            let wl = hi - lo;
-            active.clear();
-
-            for (fi, (chrom, _wt)) in rows.iter().enumerate() {
-                let slice = &chrom[lo..hi];
-                let mean: f32 = slice.iter().sum::<f32>() / wl as f32;
-                let base = fi * win;
-                let mut nsq = 0.0f32;
-                for j in 0..wl {
-                    let v = slice[j] - mean;
-                    cn[base + j] = v;
-                    nsq += v * v;
-                }
-                let norm = nsq.sqrt();
-                if norm > 1e-12 {
-                    for j in 0..wl {
-                        cn[base + j] /= norm;
-                    }
-                    active.push(fi);
-                }
-            }
-
-            // Expected-intensity-weighted mean pairwise correlation, computed
-            // in O(active) rather than O(active^2): for unit vectors u_a,
-            //   sum_{a<b} w_a w_b <u_a,u_b> = (||W||^2 - sum w_a^2) / 2,
-            //   sum_{a<b} w_a w_b          = ((sum w_a)^2 - sum w_a^2) / 2,
-            // where W = sum_a w_a u_a. The /2 cancels in the ratio.
-            wacc[..wl].fill(0.0);
-            let mut sw = 0.0f32;
-            let mut sw2 = 0.0f32;
-            for &fi in active.iter() {
-                let base = fi * win;
-                let wa = rows[fi].1;
-                sw += wa;
-                sw2 += wa * wa;
-                for j in 0..wl {
-                    wacc[j] += wa * cn[base + j];
-                }
-            }
-            let mut wnorm2 = 0.0f32;
-            for &x in &wacc[..wl] {
-                wnorm2 += x * x;
-            }
-            let den = sw * sw - sw2;
-            let coel = if den > 0.0 {
-                ((wnorm2 - sw2) / den).max(0.0)
-            } else {
-                0.0
-            };
-            traces.apex_profile[t] *= 1.0 + k * coel;
-        }
-    }
-
-    /// Cross-row coincidence-voting weighting of the apex profile.
-    ///
-    /// Per fragment row: subtract the row's global median (baseline), clip to
-    /// >=0, matched-filter with the known gaussian (sigma~1), then convert to a
-    /// robust soft vote v = sigmoid((z - tau)/s) where z = (m - median(m))/MAD.
-    /// Votes are summed across rows (expected-intensity weighted) into a support
-    /// trace; `apex_profile[t] *= 1 + K * support_norm(t)`. Because interferents
-    /// are independent across rows, only a genuine apex gets many concurrent
-    /// votes; a vote saturates so a 10x-tall interferent counts the same as a
-    /// real peak. Disabled when K<=0.
-    fn apply_vote_weighting<T: KeyLike>(&mut self, scoring_ctx: &Extraction<T>) {
-        let Self {
-            traces,
-            apex_scratch,
-            cfg,
-            ..
-        } = self;
-        let vk = cfg.vote_k;
-        if vk <= 0.0 {
-            return;
-        }
-        let tau = cfg.vote_tau;
-        let soft = cfg.vote_s.max(1e-3);
-        let n = traces.apex_profile.len();
-        if n == 0 {
-            return;
-        }
-        let collector = &scoring_ctx.chromatograms;
-
-        // Gaussian matched-filter kernel (sigma~1), 5-tap.
-        const G: [f32; 5] = [0.13534, 0.60653, 1.0, 0.60653, 0.13534];
-        let gsum: f32 = G.iter().sum();
-
-        // Reused scratch: `support` must start zeroed (accumulated across rows);
-        // r/m/tmp are fully overwritten per row.
-        let ApexScratch {
-            support, r, m, tmp, ..
-        } = apex_scratch;
-        support.clear();
-        support.resize(n, 0.0);
-        r.resize(n, 0.0);
-        m.resize(n, 0.0);
-        tmp.clear();
-        let mut wsum = 0.0f32;
-
-        for ((key, _mz), chrom) in collector.fragments.iter_mzs() {
-            let w = scoring_ctx
-                .expected_intensities
-                .get_fragment(key)
-                .unwrap_or(0.0);
-            if w <= 0.0 {
-                continue;
-            }
-
-            // Baseline = global median of the row. select_nth is O(n) vs
-            // O(n log n) for a full sort; only the k-th order statistic is
-            // needed, so partial selection is exact and cheaper.
-            tmp.clear();
-            tmp.extend_from_slice(chrom);
-            let med = *tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1;
-            for t in 0..n {
-                r[t] = (chrom[t] - med).max(0.0);
-            }
-
-            // Matched filter (edge-clamped convolution with G).
-            for t in 0..n {
-                let mut acc = 0.0f32;
-                for (di, &g) in G.iter().enumerate() {
-                    let idx = t as isize + di as isize - 2;
-                    if idx >= 0 && (idx as usize) < n {
-                        acc += g * r[idx as usize];
-                    }
-                }
-                m[t] = acc / gsum;
-            }
-
-            // Robust scale: MAD of m (both medians via O(n) selection).
-            tmp.clear();
-            tmp.extend_from_slice(m.as_slice());
-            let mmed = *tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1;
-            for t in 0..n {
-                tmp[t] = (m[t] - mmed).abs();
-            }
-            let mad = (*tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1).max(1e-6);
-
-            // Soft vote per cycle.
-            for t in 0..n {
-                let z = (m[t] - mmed) / mad;
-                let v = 1.0 / (1.0 + (-(z - tau) / soft).exp());
-                support[t] += w * v;
-            }
-            wsum += w;
-        }
-
-        if wsum <= 0.0 {
-            return;
-        }
-        for t in 0..n {
-            let s = support[t] / wsum;
-            traces.apex_profile[t] *= 1.0 + vk * s;
         }
     }
 

--- a/rust/timsseek/src/scoring/apex_finding.rs
+++ b/rust/timsseek/src/scoring/apex_finding.rs
@@ -324,6 +324,26 @@ impl Default for ApexConfig {
     }
 }
 
+/// Reusable per-worker scratch for the apex-profile weight passes. Owned by
+/// `TraceScorer` and reused across candidates so the hot loop never allocates.
+#[derive(Debug, Default)]
+struct ApexScratch {
+    /// Coelution: centered+normalized windows, row-major `[frag * win + j]`.
+    cn: Vec<f32>,
+    /// Coelution: indices of fragments with non-degenerate windows this cycle.
+    active: Vec<usize>,
+    /// Coelution: weighted sum of active unit-window vectors.
+    wacc: Vec<f32>,
+    /// Vote: per-cycle accumulated support across rows.
+    support: Vec<f32>,
+    /// Vote: baseline-subtracted, clipped row.
+    r: Vec<f32>,
+    /// Vote: matched-filtered row.
+    m: Vec<f32>,
+    /// Vote: selection buffer for median/MAD.
+    tmp: Vec<f32>,
+}
+
 /// The core engine for finding peptide apexes.
 #[derive(Debug)]
 pub struct TraceScorer {
@@ -333,6 +353,7 @@ pub struct TraceScorer {
     cosine_profile: Vec<f32>,
     scribe_profile: Vec<f32>,
     cfg: ApexConfig,
+    apex_scratch: ApexScratch,
 }
 
 #[derive(Debug)]
@@ -389,6 +410,7 @@ impl TraceScorer {
             cosine_profile: Vec::with_capacity(capacity),
             scribe_profile: Vec::with_capacity(capacity),
             cfg: ApexConfig::default(),
+            apex_scratch: ApexScratch::default(),
         }
     }
 
@@ -816,13 +838,19 @@ impl TraceScorer {
     /// peaks and suppresses uncorrelated random-interferent pileups.
     /// `apex_profile[t] *= 1 + K * max(coel, 0)`. Disabled when K<=0.
     fn apply_coelution_weighting<T: KeyLike>(&mut self, scoring_ctx: &Extraction<T>) {
-        let k = self.cfg.coel_k;
+        let Self {
+            traces,
+            apex_scratch,
+            cfg,
+            ..
+        } = self;
+        let k = cfg.coel_k;
         if k <= 0.0 {
             return;
         }
-        let w = self.cfg.coel_w.max(1.0) as usize;
+        let w = cfg.coel_w.max(1.0) as usize;
         let collector = &scoring_ctx.chromatograms;
-        let n = self.traces.apex_profile.len();
+        let n = traces.apex_profile.len();
         if n == 0 {
             return;
         }
@@ -843,16 +871,20 @@ impl TraceScorer {
         }
 
         let win = 2 * w + 1;
-        // Centered+normalized window per fragment, row-major [frag * win + j].
-        let mut cn: Vec<f32> = vec![0.0; rows.len() * win];
-        let mut active: Vec<usize> = Vec::with_capacity(rows.len());
-        // Weighted sum of active unit-window vectors (reused per cycle).
-        let mut wacc: Vec<f32> = vec![0.0; win];
+        // Reused scratch: centered+normalized windows [frag * win + j], the
+        // active-fragment index list, and the weighted window-sum vector.
+        let ApexScratch {
+            cn, active, wacc, ..
+        } = apex_scratch;
+        cn.clear();
+        cn.resize(rows.len() * win, 0.0);
+        wacc.clear();
+        wacc.resize(win, 0.0);
 
         for t in 0..n {
             // The weight only ever multiplies apex_profile[t]; a zero cycle
             // stays zero for any coel, so skip its O(rows*win) window work.
-            if self.traces.apex_profile[t] == 0.0 {
+            if traces.apex_profile[t] == 0.0 {
                 continue;
             }
 
@@ -888,7 +920,7 @@ impl TraceScorer {
             wacc[..wl].fill(0.0);
             let mut sw = 0.0f32;
             let mut sw2 = 0.0f32;
-            for &fi in &active {
+            for &fi in active.iter() {
                 let base = fi * win;
                 let wa = rows[fi].1;
                 sw += wa;
@@ -907,7 +939,7 @@ impl TraceScorer {
             } else {
                 0.0
             };
-            self.traces.apex_profile[t] *= 1.0 + k * coel;
+            traces.apex_profile[t] *= 1.0 + k * coel;
         }
     }
 
@@ -922,13 +954,19 @@ impl TraceScorer {
     /// votes; a vote saturates so a 10x-tall interferent counts the same as a
     /// real peak. Disabled when K<=0.
     fn apply_vote_weighting<T: KeyLike>(&mut self, scoring_ctx: &Extraction<T>) {
-        let vk = self.cfg.vote_k;
+        let Self {
+            traces,
+            apex_scratch,
+            cfg,
+            ..
+        } = self;
+        let vk = cfg.vote_k;
         if vk <= 0.0 {
             return;
         }
-        let tau = self.cfg.vote_tau;
-        let soft = self.cfg.vote_s.max(1e-3);
-        let n = self.traces.apex_profile.len();
+        let tau = cfg.vote_tau;
+        let soft = cfg.vote_s.max(1e-3);
+        let n = traces.apex_profile.len();
         if n == 0 {
             return;
         }
@@ -938,11 +976,17 @@ impl TraceScorer {
         const G: [f32; 5] = [0.13534, 0.60653, 1.0, 0.60653, 0.13534];
         let gsum: f32 = G.iter().sum();
 
-        let mut support = vec![0.0f32; n];
+        // Reused scratch: `support` must start zeroed (accumulated across rows);
+        // r/m/tmp are fully overwritten per row.
+        let ApexScratch {
+            support, r, m, tmp, ..
+        } = apex_scratch;
+        support.clear();
+        support.resize(n, 0.0);
+        r.resize(n, 0.0);
+        m.resize(n, 0.0);
+        tmp.clear();
         let mut wsum = 0.0f32;
-        let mut r = vec![0.0f32; n];
-        let mut m = vec![0.0f32; n];
-        let mut tmp = vec![0.0f32; n];
 
         for ((key, _mz), chrom) in collector.fragments.iter_mzs() {
             let w = scoring_ctx
@@ -977,7 +1021,7 @@ impl TraceScorer {
 
             // Robust scale: MAD of m (both medians via O(n) selection).
             tmp.clear();
-            tmp.extend_from_slice(&m);
+            tmp.extend_from_slice(m.as_slice());
             let mmed = *tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1;
             for t in 0..n {
                 tmp[t] = (m[t] - mmed).abs();
@@ -998,7 +1042,7 @@ impl TraceScorer {
         }
         for t in 0..n {
             let s = support[t] / wsum;
-            self.traces.apex_profile[t] *= 1.0 + vk * s;
+            traces.apex_profile[t] *= 1.0 + vk * s;
         }
     }
 

--- a/rust/timsseek/src/scoring/apex_finding.rs
+++ b/rust/timsseek/src/scoring/apex_finding.rs
@@ -296,6 +296,10 @@ pub struct ApexConfig {
     pub blur_passes: usize,
     /// Joint-apex snap window: use joint apex if within this many cycles.
     pub joint_snap: usize,
+    /// Ratio-free coelution weight strength (0 = disabled).
+    pub coel_k: f32,
+    /// Coelution correlation half-window (cycles).
+    pub coel_w: f32,
 }
 
 impl Default for ApexConfig {
@@ -306,6 +310,8 @@ impl Default for ApexConfig {
             s_ratio: 1.75,
             blur_passes: 1,
             joint_snap: 1,
+            coel_k: 1.04,
+            coel_w: 2.0,
         }
     }
 }
@@ -414,6 +420,7 @@ impl TraceScorer {
 
         self.compute_pass_1(scoring_ctx)?;
         self.compute_main_score_trace();
+        self.apply_coelution_weighting(scoring_ctx);
         self.build_profiles_cached();
 
         Ok(())
@@ -788,6 +795,94 @@ impl TraceScorer {
 
         for _ in 0..self.cfg.blur_passes {
             gaussblur_in_place(&mut self.traces.apex_profile);
+        }
+    }
+
+    /// Per-cycle ratio-free coelution weighting of the apex profile.
+    ///
+    /// For each cycle, over a +/-W window, center-normalizes each active
+    /// fragment's XIC slice and takes the expected-intensity-weighted mean
+    /// pairwise correlation. Because slices are centered+normalized, this is
+    /// independent of absolute fragment ratios: it rewards genuine co-eluting
+    /// peaks and suppresses uncorrelated random-interferent pileups.
+    /// `apex_profile[t] *= 1 + K * max(coel, 0)`. Disabled when K<=0.
+    fn apply_coelution_weighting<T: KeyLike>(&mut self, scoring_ctx: &Extraction<T>) {
+        let k = self.cfg.coel_k;
+        if k <= 0.0 {
+            return;
+        }
+        let w = self.cfg.coel_w.max(1.0) as usize;
+        let collector = &scoring_ctx.chromatograms;
+        let n = self.traces.apex_profile.len();
+        if n == 0 {
+            return;
+        }
+
+        // Active fragments: (per-cycle slice, expected-intensity weight).
+        let mut rows: Vec<(&[f32], f32)> = Vec::new();
+        for ((key, _mz), chrom) in collector.fragments.iter_mzs() {
+            let exp = scoring_ctx
+                .expected_intensities
+                .get_fragment(key)
+                .unwrap_or(0.0);
+            if exp > 0.0 {
+                rows.push((chrom, exp));
+            }
+        }
+        if rows.len() < 2 {
+            return;
+        }
+
+        let win = 2 * w + 1;
+        // Centered+normalized window per fragment, row-major [frag * win + j].
+        let mut cn: Vec<f32> = vec![0.0; rows.len() * win];
+        let mut active: Vec<usize> = Vec::with_capacity(rows.len());
+
+        for t in 0..n {
+            let lo = t.saturating_sub(w);
+            let hi = (t + w + 1).min(n);
+            let wl = hi - lo;
+            active.clear();
+
+            for (fi, (chrom, _wt)) in rows.iter().enumerate() {
+                let slice = &chrom[lo..hi];
+                let mean: f32 = slice.iter().sum::<f32>() / wl as f32;
+                let base = fi * win;
+                let mut nsq = 0.0f32;
+                for j in 0..wl {
+                    let v = slice[j] - mean;
+                    cn[base + j] = v;
+                    nsq += v * v;
+                }
+                let norm = nsq.sqrt();
+                if norm > 1e-12 {
+                    for j in 0..wl {
+                        cn[base + j] /= norm;
+                    }
+                    active.push(fi);
+                }
+            }
+
+            let mut num = 0.0f32;
+            let mut den = 0.0f32;
+            for a in 0..active.len() {
+                let ia = active[a];
+                let ba = ia * win;
+                let wa = rows[ia].1;
+                for b in (a + 1)..active.len() {
+                    let ib = active[b];
+                    let bb = ib * win;
+                    let ww = wa * rows[ib].1;
+                    let mut corr = 0.0f32;
+                    for j in 0..wl {
+                        corr += cn[ba + j] * cn[bb + j];
+                    }
+                    num += ww * corr;
+                    den += ww;
+                }
+            }
+            let coel = if den > 0.0 { num / den } else { 0.0 };
+            self.traces.apex_profile[t] *= 1.0 + k * coel.max(0.0);
         }
     }
 

--- a/rust/timsseek/src/scoring/apex_finding.rs
+++ b/rust/timsseek/src/scoring/apex_finding.rs
@@ -280,6 +280,36 @@ impl ElutionTraces {
     }
 }
 
+/// Tunable apex-profile knobs. `Default` reproduces the historical `main`
+/// behavior exactly (cos^3 * I^1 base, additive scribe floor 0.5, no blur,
+/// joint-apex snap window 3, all optional weight terms disabled). Ablation
+/// flips individual fields; shipped values live in `Default`.
+#[derive(Debug, Clone)]
+pub struct ApexConfig {
+    /// Cosine exponent in the base profile: `cos^cos_pow`.
+    pub cos_pow: f32,
+    /// Log-intensity exponent in the base profile: `I^i_exp`.
+    pub i_exp: f32,
+    /// Additive scribe floor: `apex = C * (s_ratio + s_norm)`.
+    pub s_ratio: f32,
+    /// Gaussian-blur passes applied to the base profile (0 = none).
+    pub blur_passes: usize,
+    /// Joint-apex snap window: use joint apex if within this many cycles.
+    pub joint_snap: usize,
+}
+
+impl Default for ApexConfig {
+    fn default() -> Self {
+        Self {
+            cos_pow: 3.0,
+            i_exp: 1.0,
+            s_ratio: 0.5,
+            blur_passes: 0,
+            joint_snap: 3,
+        }
+    }
+}
+
 /// The core engine for finding peptide apexes.
 #[derive(Debug)]
 pub struct TraceScorer {
@@ -288,6 +318,7 @@ pub struct TraceScorer {
     coel_scratch: crate::scoring::scores::apex_features::CoelutionScratch,
     cosine_profile: Vec<f32>,
     scribe_profile: Vec<f32>,
+    cfg: ApexConfig,
 }
 
 #[derive(Debug)]
@@ -343,6 +374,7 @@ impl TraceScorer {
                 ),
             cosine_profile: Vec::with_capacity(capacity),
             scribe_profile: Vec::with_capacity(capacity),
+            cfg: ApexConfig::default(),
         }
     }
 
@@ -467,7 +499,9 @@ impl TraceScorer {
 
         // Joint apex: find precursor-fragment agreement, but use clicked cycle if far from it
         let joint_apex = find_joint_apex(&self.cosine_profile, &self.traces.ms1_precursor_trace);
-        let effective_apex = if (joint_apex as i64 - cycle as i64).unsigned_abs() as usize <= 3 {
+        let effective_apex = if (joint_apex as i64 - cycle as i64).unsigned_abs() as usize
+            <= self.cfg.joint_snap
+        {
             joint_apex
         } else {
             cycle
@@ -740,7 +774,7 @@ impl TraceScorer {
         for i in 0..len {
             let cos = self.traces.cosine_trace[i];
             let intensity = self.traces.ms2_log_intensity[i];
-            let c = cos * cos * cos * intensity; // cos^3 * I
+            let c = cos.powf(self.cfg.cos_pow) * intensity.powf(self.cfg.i_exp);
 
             let s = self.traces.ms2_scribe[i] * intensity;
             let s_norm = if s_range > 0.0 {
@@ -749,7 +783,11 @@ impl TraceScorer {
                 0.5 // Degrade to cosine-only when scribe is constant
             };
 
-            self.traces.apex_profile.push(c * (0.5 + s_norm));
+            self.traces.apex_profile.push(c * (self.cfg.s_ratio + s_norm));
+        }
+
+        for _ in 0..self.cfg.blur_passes {
+            gaussblur_in_place(&mut self.traces.apex_profile);
         }
     }
 

--- a/rust/timsseek/src/scoring/apex_finding.rs
+++ b/rust/timsseek/src/scoring/apex_finding.rs
@@ -280,10 +280,9 @@ impl ElutionTraces {
     }
 }
 
-/// Tunable apex-profile knobs. `Default` reproduces the historical `main`
-/// behavior exactly (cos^3 * I^1 base, additive scribe floor 0.5, no blur,
-/// joint-apex snap window 3, all optional weight terms disabled). Ablation
-/// flips individual fields; shipped values live in `Default`.
+/// Tunable apex-profile knobs. `Default` holds the bench-validated shipping
+/// values (see the apex_sim canonical suite). Ablation flips individual fields;
+/// shipped values live in `Default`.
 #[derive(Debug, Clone)]
 pub struct ApexConfig {
     /// Cosine exponent in the base profile: `cos^cos_pow`.
@@ -300,6 +299,12 @@ pub struct ApexConfig {
     pub coel_k: f32,
     /// Coelution correlation half-window (cycles).
     pub coel_w: f32,
+    /// Cross-row coincidence-vote weight strength (0 = disabled).
+    pub vote_k: f32,
+    /// Vote sigmoid threshold (z-score units).
+    pub vote_tau: f32,
+    /// Vote sigmoid softness (z-score units).
+    pub vote_s: f32,
 }
 
 impl Default for ApexConfig {
@@ -312,6 +317,9 @@ impl Default for ApexConfig {
             joint_snap: 1,
             coel_k: 1.04,
             coel_w: 2.0,
+            vote_k: 14.43,
+            vote_tau: 1.28,
+            vote_s: 0.42,
         }
     }
 }
@@ -421,6 +429,7 @@ impl TraceScorer {
         self.compute_pass_1(scoring_ctx)?;
         self.compute_main_score_trace();
         self.apply_coelution_weighting(scoring_ctx);
+        self.apply_vote_weighting(scoring_ctx);
         self.build_profiles_cached();
 
         Ok(())
@@ -883,6 +892,98 @@ impl TraceScorer {
             }
             let coel = if den > 0.0 { num / den } else { 0.0 };
             self.traces.apex_profile[t] *= 1.0 + k * coel.max(0.0);
+        }
+    }
+
+    /// Cross-row coincidence-voting weighting of the apex profile.
+    ///
+    /// Per fragment row: subtract the row's global median (baseline), clip to
+    /// >=0, matched-filter with the known gaussian (sigma~1), then convert to a
+    /// robust soft vote v = sigmoid((z - tau)/s) where z = (m - median(m))/MAD.
+    /// Votes are summed across rows (expected-intensity weighted) into a support
+    /// trace; `apex_profile[t] *= 1 + K * support_norm(t)`. Because interferents
+    /// are independent across rows, only a genuine apex gets many concurrent
+    /// votes; a vote saturates so a 10x-tall interferent counts the same as a
+    /// real peak. Disabled when K<=0.
+    fn apply_vote_weighting<T: KeyLike>(&mut self, scoring_ctx: &Extraction<T>) {
+        let vk = self.cfg.vote_k;
+        if vk <= 0.0 {
+            return;
+        }
+        let tau = self.cfg.vote_tau;
+        let soft = self.cfg.vote_s.max(1e-3);
+        let n = self.traces.apex_profile.len();
+        if n == 0 {
+            return;
+        }
+        let collector = &scoring_ctx.chromatograms;
+
+        // Gaussian matched-filter kernel (sigma~1), 5-tap.
+        const G: [f32; 5] = [0.13534, 0.60653, 1.0, 0.60653, 0.13534];
+        let gsum: f32 = G.iter().sum();
+
+        let mut support = vec![0.0f32; n];
+        let mut wsum = 0.0f32;
+        let mut r = vec![0.0f32; n];
+        let mut m = vec![0.0f32; n];
+        let mut tmp = vec![0.0f32; n];
+
+        for ((key, _mz), chrom) in collector.fragments.iter_mzs() {
+            let w = scoring_ctx
+                .expected_intensities
+                .get_fragment(key)
+                .unwrap_or(0.0);
+            if w <= 0.0 {
+                continue;
+            }
+
+            // Baseline = global median of the row.
+            tmp.clear();
+            tmp.extend_from_slice(chrom);
+            tmp.sort_unstable_by(f32::total_cmp);
+            let med = tmp[n / 2];
+            for t in 0..n {
+                r[t] = (chrom[t] - med).max(0.0);
+            }
+
+            // Matched filter (edge-clamped convolution with G).
+            for t in 0..n {
+                let mut acc = 0.0f32;
+                for (di, &g) in G.iter().enumerate() {
+                    let idx = t as isize + di as isize - 2;
+                    if idx >= 0 && (idx as usize) < n {
+                        acc += g * r[idx as usize];
+                    }
+                }
+                m[t] = acc / gsum;
+            }
+
+            // Robust scale: MAD of m.
+            tmp.clear();
+            tmp.extend_from_slice(&m);
+            tmp.sort_unstable_by(f32::total_cmp);
+            let mmed = tmp[n / 2];
+            for t in 0..n {
+                tmp[t] = (m[t] - mmed).abs();
+            }
+            tmp.sort_unstable_by(f32::total_cmp);
+            let mad = tmp[n / 2].max(1e-6);
+
+            // Soft vote per cycle.
+            for t in 0..n {
+                let z = (m[t] - mmed) / mad;
+                let v = 1.0 / (1.0 + (-(z - tau) / soft).exp());
+                support[t] += w * v;
+            }
+            wsum += w;
+        }
+
+        if wsum <= 0.0 {
+            return;
+        }
+        for t in 0..n {
+            let s = support[t] / wsum;
+            self.traces.apex_profile[t] *= 1.0 + vk * s;
         }
     }
 

--- a/rust/timsseek/src/scoring/apex_finding.rs
+++ b/rust/timsseek/src/scoring/apex_finding.rs
@@ -937,11 +937,12 @@ impl TraceScorer {
                 continue;
             }
 
-            // Baseline = global median of the row.
+            // Baseline = global median of the row. select_nth is O(n) vs
+            // O(n log n) for a full sort; only the k-th order statistic is
+            // needed, so partial selection is exact and cheaper.
             tmp.clear();
             tmp.extend_from_slice(chrom);
-            tmp.sort_unstable_by(f32::total_cmp);
-            let med = tmp[n / 2];
+            let med = *tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1;
             for t in 0..n {
                 r[t] = (chrom[t] - med).max(0.0);
             }
@@ -958,16 +959,14 @@ impl TraceScorer {
                 m[t] = acc / gsum;
             }
 
-            // Robust scale: MAD of m.
+            // Robust scale: MAD of m (both medians via O(n) selection).
             tmp.clear();
             tmp.extend_from_slice(&m);
-            tmp.sort_unstable_by(f32::total_cmp);
-            let mmed = tmp[n / 2];
+            let mmed = *tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1;
             for t in 0..n {
                 tmp[t] = (m[t] - mmed).abs();
             }
-            tmp.sort_unstable_by(f32::total_cmp);
-            let mad = tmp[n / 2].max(1e-6);
+            let mad = (*tmp.select_nth_unstable_by(n / 2, f32::total_cmp).1).max(1e-6);
 
             // Soft vote per cycle.
             for t in 0..n {

--- a/rust/timsseek/src/scoring/mod.rs
+++ b/rust/timsseek/src/scoring/mod.rs
@@ -1,4 +1,5 @@
 mod accumulator;
+pub mod apex;
 pub mod apex_finding;
 pub mod extraction;
 pub mod full_results;


### PR DESCRIPTION
Clean re-implementation of the apex-profile weighting experiments from the
apex-autoresearch branch, rebuilt off main as maintainable, tested, and
runtime-optimized code. Every term was bench-validated on the apex_sim
canonical suite; only terms that clear the agreed keep-bar ship.

## What changed

Base apex profile retuned and two per-cycle weighting passes added, applied to
apex_profile before peak-picking:

- Base: cos^0.5 * I^0.75 * (1.75 + s_norm), one gaussian-blur pass, joint-apex
  snap window 1 (was cos^3 * I, floor 0.5, no blur, snap 3).
- Coelution weight: ratio-free expected-intensity-weighted mean pairwise
  correlation of center-normalized fragment XIC windows. Rewards genuine
  co-elution, independent of absolute fragment ratios.
- Vote weight: robust per-row matched-filter soft votes summed across
  fragments; saturating votes let a real multi-fragment apex win over tall
  single-row interferents.

All knobs live in one ApexConfig (bench-tuned Default, no env-var globals). The
passes are pure kernels in scoring/apex/{coelution,vote}.rs over
(profile, rows, cfg, scratch), decoupled from the extraction data model and
unit-tested.

## Ablation (keep-bar: SUM gain > 2.0 on the 6-scenario suite; noise = 0)

  term                     decision   SUM
  base retune              KEEP       267.9 -> 326.2  (+58.3)
  gaussblur (1 pass)       KEEP       included above
  joint-snap 1             KEEP       +1.5 (free: existing constant, no new code)
  coelution weight         KEEP       326.2 -> 341.5  (+15.3)
  MS1 isotope-coherence    DROP       +1.3 (< 2.0; regressed mismatched, and
                                      dropping it keeps the stack
                                      precursor-independent)
  vote weight              KEEP       341.5 -> 405.1  (+63.6)

Rounded exponents/strengths (0.5 / 0.75 / 1.75; coel_k 1.0, vote_k 14, tau 1.3,
s 0.4) match or beat the raw Optuna values, so no over-precise magic constants
ship. Also added an absent_precursor bench scenario as a permanent guard
against over-reliance on precursor signal.

## Runtime

The passes run per-candidate on rayon workers. Cost recovered from 91 to 51
us/run, result-identical (SUM unchanged at each step):

- vote median/MAD: 3 full sorts/row -> select_nth (O(n)).           91 -> 59
- coelution: pairwise O(rows^2) -> ||W||^2 closed form (O(rows))
  + skip zero-profile cycles.                                        59 -> 51
- per-worker scratch: no per-candidate allocation.                   parity

## vs apex-autoresearch branch

  branch (isotope on, unoptimized):  SUM 494.7  @ 91.8 us/run
  this PR   (isotope dropped, opt):  SUM 491.6  @ 51.2 us/run

-0.7% SUM for +44% throughput, a simpler precursor-independent stack, 3 fewer
knobs, and unit tests. The 3.4-point delta is entirely the dropped isotope term.

## Validation

- cargo test -p timsseek: 94 passed (4 new apex unit tests).
- cargo build -p timsseek --release, cargo build -p apex_sim --release: clean.
- No env/LazyLock knobs remain (grep clean).
- Bench: bash bench_out/score.sh <label>  (apex_sim canonical suite, synthetic).
