### PR TITLE
apex_sim: production-realistic bench conditions + score-discrimination (AUC)

### DIFF
--- a/rust/apex_sim/examples/bench.rs
+++ b/rust/apex_sim/examples/bench.rs
@@ -1,47 +1,87 @@
-//! Apex-finder bench: runs the whole catalog of canonical scenarios
-//! (`apex_sim::bench::canonical_suite`) at once and prints per-scenario detail
-//! plus a comparison summary table.
+//! Apex-finder + score benches.
 //!
-//! Each scenario runs `n_runs` seeds of one fixed config; "sensitivity" is the
-//! fraction of runs whose pass-2 apex lands within `tol` cycles of truth.
+//! Runs three suites:
+//!   * canonical (historical 245-cyc scenarios; apex-recovery only),
+//!   * broad (production Phase-1 window ~1695 cyc; apex-recovery), and
+//!   * narrow (production Phase-3 window ~150 cyc; apex-recovery + score AUC).
+//! "recovery" = fraction of runs whose pass-2 apex lands within `tol` cycles of
+//! the (jittered) truth. "AUC" = ROC-AUC separating the Pass-2 score of a real
+//! peptide from a pure-noise twin (signal-vs-noise discrimination).
 //!
 //! Run:
 //!   cargo run -p apex_sim --release --example bench
-//!   cargo run -p apex_sim --release --example bench -- 500 2
-//!     (positional: <n_runs> <tolerance_cycles>)
+//!   cargo run -p apex_sim --release --example bench -- 2000 2 500
+//!     (positional: <n_runs> <tolerance_cycles> <broad_n_runs>)
 
 use apex_sim::bench::{
+    SensitivityReport,
+    broad_suite,
     canonical_suite,
+    narrow_suite,
+    run_discrimination,
     run_sensitivity,
 };
+use apex_sim::sim::SimParams;
 
-fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let n_runs: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(2000);
-    let tol: i64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(2);
+/// Run a suite and print a comparison summary table under `=== {title} ===`.
+/// The canonical suite passes `title = "summary"` so `bench_out/score.sh`
+/// (which keys on `=== summary`) keeps working.
+fn run_and_print_recovery(
+    suite: &[(&'static str, SimParams)],
+    n_runs: usize,
+    tol: i64,
+    title: &str,
+) {
+    let rows: Vec<(&str, SensitivityReport)> = suite
+        .iter()
+        .map(|(name, cfg)| (*name, run_sensitivity(cfg, n_runs, tol)))
+        .collect();
 
-    let suite = canonical_suite();
-    let mut rows = Vec::with_capacity(suite.len());
-    for (name, cfg) in &suite {
-        let report = run_sensitivity(cfg, n_runs, tol);
-        report.print(name);
-        println!();
-        rows.push((*name, report));
-    }
-
-    println!("=== summary (n={n_runs}, tol=±{tol} cycles) ===");
+    println!("=== {title} (n={n_runs}, tol=±{tol} cycles) ===");
     println!(
-        "  {:<26} {:>7} {:>7} {:>8} {:>9}",
+        "  {:<28} {:>7} {:>7} {:>8} {:>9}",
         "scenario", "pass2%", "pass1%", "medErr", "us/run"
     );
     for (name, r) in &rows {
         println!(
-            "  {:<26} {:>7.1} {:>7.1} {:>8} {:>9.2}",
+            "  {:<28} {:>7.1} {:>7.1} {:>8} {:>9.2}",
             name,
             r.pass2_pct(),
             r.pass1_pct(),
             r.median_err(),
             r.score_us_per_run(),
+        );
+    }
+    println!();
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n_runs: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(2000);
+    let tol: i64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(2);
+    // Broad sims are ~42x heavier per run; default to fewer.
+    let broad_runs: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(500);
+
+    // Canonical (historical) apex-recovery suite. Header stays `=== summary`.
+    run_and_print_recovery(&canonical_suite(), n_runs, tol, "summary");
+
+    // Broad apex-finding (production Phase-1 window ~1695 cyc).
+    run_and_print_recovery(&broad_suite(), broad_runs, tol, "broad apex-finding");
+
+    // Narrow scoring (production Phase-3 window ~150 cyc): apex recovery.
+    run_and_print_recovery(&narrow_suite(), n_runs, tol, "narrow recovery");
+
+    // Narrow score discrimination: signal-present vs pure-noise (ROC-AUC).
+    println!("=== narrow score discrimination (AUC, n_pairs={n_runs}) ===");
+    println!(
+        "  {:<28} {:>7} {:>12} {:>12}",
+        "scenario", "AUC", "med+signal", "med-noise"
+    );
+    for (name, cfg) in &narrow_suite() {
+        let d = run_discrimination(cfg, n_runs);
+        println!(
+            "  {:<28} {:>7.3} {:>12.3e} {:>12.3e}",
+            name, d.auc, d.median_present, d.median_absent
         );
     }
 }

--- a/rust/apex_sim/src/bench.rs
+++ b/rust/apex_sim/src/bench.rs
@@ -116,7 +116,9 @@ pub fn canonical_suite() -> Vec<(&'static str, SimParams)> {
 /// collect apex-recovery + timing stats. A hit = pass-2 apex within `tol`
 /// cycles of the configured `apex_cycle`.
 pub fn run_sensitivity(base: &SimParams, n_runs: usize, tol: i64) -> SensitivityReport {
-    let true_apex = base.apex_cycle.round() as i64;
+    // Echoed in the report header; each run is scored against its OWN realized
+    // apex (jitter varies it per seed), not this nominal value.
+    let nominal_apex = base.apex_cycle.round() as i64;
     // rt mapping is seed-independent, so one mapper serves every run.
     let map = base.rt_mapper();
 
@@ -139,6 +141,7 @@ pub fn run_sensitivity(base: &SimParams, n_runs: usize, tol: i64) -> Sensitivity
     let mut scorer = TraceScorer::new(base.n_cycles, base.real_fragments.len().max(1));
     let t_score = Instant::now();
     for data in &sims {
+        let true_apex = data.realized_apex_cycle.round() as i64;
         match scorer::run_with(&mut scorer, &data.extraction, &map) {
             Ok((pass1, pass2)) => {
                 if (pass1.apex_cycle as i64 - true_apex).abs() <= tol {
@@ -159,7 +162,7 @@ pub fn run_sensitivity(base: &SimParams, n_runs: usize, tol: i64) -> Sensitivity
     SensitivityReport {
         n: n_runs,
         tol,
-        true_apex,
+        true_apex: nominal_apex,
         build_ms,
         score_ms,
         errors,

--- a/rust/apex_sim/src/bench.rs
+++ b/rust/apex_sim/src/bench.rs
@@ -112,6 +112,100 @@ pub fn canonical_suite() -> Vec<(&'static str, SimParams)> {
     ]
 }
 
+/// Production-realistic BROAD apex-finding suite (Phase-1 window ~1695 cycles,
+/// RT-unrestricted). Interferents are DENSITY-scaled (fixed per-cycle rate) and
+/// the apex is jittered per seed with a sub-cycle offset, so widening the window
+/// does not make the task artificially easy and the finder faces a moving,
+/// off-grid target. Each scenario is its own line so it can be commented out.
+pub fn broad_suite() -> Vec<(&'static str, SimParams)> {
+    let base = || {
+        let mut p = SimParams::default();
+        p.n_cycles = 1695;
+        p.apex_cycle = 847.0;
+        p.apex_jitter = Some(800.0);
+        p.width_sigma = 1.0;
+        p.seed = 680;
+        p.random_peaks.count = 0;
+        p.random_peaks.density_per_cycle = 2.5; // ~ current 100/40 density
+        p
+    };
+
+    let mut clean = base();
+    clean.noise_floor = 0.02;
+    clean.random_peaks.enabled = false;
+
+    let mut moderate = base();
+    moderate.noise_floor = 0.2;
+
+    let mut stress = base();
+    stress.noise_floor = 0.5;
+
+    let mut hard = base();
+    hard.noise_floor = 0.5;
+    hard.random_peaks.hardness = 3.0; // 3x interferent density
+
+    let mut mismatched = base();
+    mismatched.noise_floor = 0.5;
+    for f in &mut mismatched.real_fragments {
+        f.obs_scale = f.theo_intensity;
+        f.theo_intensity = 1.0;
+    }
+
+    vec![
+        ("broad_clean", clean),
+        ("broad_moderate_noise", moderate),
+        ("broad_high_noise+interf", stress),
+        ("broad_hard_3x_density", hard),
+        ("broad_mismatched_library", mismatched),
+    ]
+}
+
+/// Production-realistic NARROW scoring suite (Phase-3 calibrated window ~150
+/// cycles). Same density-scaled interferents + jittered sub-cycle apex; used
+/// for BOTH apex recovery and score discrimination (`run_discrimination`).
+pub fn narrow_suite() -> Vec<(&'static str, SimParams)> {
+    let base = || {
+        let mut p = SimParams::default();
+        p.n_cycles = 150;
+        p.apex_cycle = 75.0;
+        p.apex_jitter = Some(60.0);
+        p.width_sigma = 1.0;
+        p.seed = 680;
+        p.random_peaks.count = 0;
+        p.random_peaks.density_per_cycle = 2.5;
+        p
+    };
+
+    let mut clean = base();
+    clean.noise_floor = 0.02;
+    clean.random_peaks.enabled = false;
+
+    let mut moderate = base();
+    moderate.noise_floor = 0.2;
+
+    let mut stress = base();
+    stress.noise_floor = 0.5;
+
+    let mut hard = base();
+    hard.noise_floor = 0.5;
+    hard.random_peaks.hardness = 3.0;
+
+    let mut mismatched = base();
+    mismatched.noise_floor = 0.5;
+    for f in &mut mismatched.real_fragments {
+        f.obs_scale = f.theo_intensity;
+        f.theo_intensity = 1.0;
+    }
+
+    vec![
+        ("narrow_clean", clean),
+        ("narrow_moderate_noise", moderate),
+        ("narrow_high_noise+interf", stress),
+        ("narrow_hard_3x_density", hard),
+        ("narrow_mismatched_library", mismatched),
+    ]
+}
+
 /// Run `n_runs` scored simulations of `base` (varying only the seed) and
 /// collect apex-recovery + timing stats. A hit = pass-2 apex within `tol`
 /// cycles of the configured `apex_cycle`.

--- a/rust/apex_sim/src/bench.rs
+++ b/rust/apex_sim/src/bench.rs
@@ -126,7 +126,7 @@ pub fn broad_suite() -> Vec<(&'static str, SimParams)> {
         p.width_sigma = 1.0;
         p.seed = 680;
         p.random_peaks.count = 0;
-        p.random_peaks.density_per_cycle = 2.5; // ~ current 100/40 density
+        p.random_peaks.density_per_cycle = 0.41; // matches canonical 100/245
         p
     };
 
@@ -172,7 +172,7 @@ pub fn narrow_suite() -> Vec<(&'static str, SimParams)> {
         p.width_sigma = 1.0;
         p.seed = 680;
         p.random_peaks.count = 0;
-        p.random_peaks.density_per_cycle = 2.5;
+        p.random_peaks.density_per_cycle = 0.41;
         p
     };
 

--- a/rust/apex_sim/src/bench.rs
+++ b/rust/apex_sim/src/bench.rs
@@ -257,3 +257,118 @@ impl SensitivityReport {
         println!();
     }
 }
+
+/// Present-vs-absent score-discrimination result for one scenario.
+pub struct DiscriminationReport {
+    pub n_pairs: usize,
+    /// ROC-AUC = P(score_present > score_absent), 0.5 tie credit. 1.0 = perfect
+    /// signal/noise separation, 0.5 = useless.
+    pub auc: f64,
+    pub median_present: f32,
+    pub median_absent: f32,
+}
+
+/// ROC-AUC of `present` vs `absent` score populations via the average-rank
+/// Mann-Whitney statistic: `P(present > absent)` with 0.5 credit for ties.
+pub fn roc_auc(present: &[f32], absent: &[f32]) -> f64 {
+    let (np, na) = (present.len(), absent.len());
+    if np == 0 || na == 0 {
+        return f64::NAN;
+    }
+    // Combined values tagged present(true)/absent(false), sorted ascending.
+    let mut all: Vec<(f32, bool)> = present
+        .iter()
+        .map(|&v| (v, true))
+        .chain(absent.iter().map(|&v| (v, false)))
+        .collect();
+    all.sort_by(|a, b| a.0.total_cmp(&b.0));
+    // Sum of average ranks (1-based) assigned to present values.
+    let mut rank_sum_present = 0.0f64;
+    let mut i = 0usize;
+    while i < all.len() {
+        let mut j = i + 1;
+        while j < all.len() && all[j].0 == all[i].0 {
+            j += 1;
+        }
+        // Mean rank of the tie block covering positions (i+1..=j).
+        let avg_rank = ((i + 1 + j) as f64) / 2.0;
+        for entry in &all[i..j] {
+            if entry.1 {
+                rank_sum_present += avg_rank;
+            }
+        }
+        i = j;
+    }
+    let u = rank_sum_present - (np * (np + 1)) as f64 / 2.0;
+    u / (np as f64 * na as f64)
+}
+
+/// Score `n_pairs` matched present/absent realizations and report how well the
+/// production Pass-2 score separates real signal from pure noise. Each pair
+/// shares a seed, so the "absent" twin (all real fragments `obs_scale = 0`) has
+/// IDENTICAL noise + interferents — only the real peak differs.
+pub fn run_discrimination(base: &SimParams, n_pairs: usize) -> DiscriminationReport {
+    let map = base.rt_mapper();
+    let mut scorer = TraceScorer::new(base.n_cycles, base.real_fragments.len().max(1));
+    let mut present: Vec<f32> = Vec::with_capacity(n_pairs);
+    let mut absent: Vec<f32> = Vec::with_capacity(n_pairs);
+    for i in 0..n_pairs {
+        let mut pp = base.clone();
+        pp.seed = base.seed.wrapping_add(i as u64);
+        // Pure-noise twin: NO real signal at all (fragments AND precursor
+        // zeroed), identical seed => identical noise + interferents. Zeroing
+        // only fragments would leave the precursor isotope peaks in place and
+        // the score would still see real signal.
+        let mut ap = pp.clone();
+        for f in &mut ap.real_fragments {
+            f.obs_scale = 0.0;
+        }
+        ap.precursor_intensity = 0.0;
+        if let Ok((_, s)) = scorer::run_with(&mut scorer, &sim::build(&pp).extraction, &map) {
+            present.push(s.score);
+        }
+        if let Ok((_, s)) = scorer::run_with(&mut scorer, &sim::build(&ap).extraction, &map) {
+            absent.push(s.score);
+        }
+    }
+    let median = |mut v: Vec<f32>| {
+        v.sort_by(f32::total_cmp);
+        v.get(v.len() / 2).copied().unwrap_or(f32::NAN)
+    };
+    let auc = roc_auc(&present, &absent);
+    DiscriminationReport {
+        n_pairs,
+        auc,
+        median_present: median(present),
+        median_absent: median(absent),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roc_auc_basic() {
+        assert!((roc_auc(&[3.0, 4.0, 5.0], &[0.0, 1.0, 2.0]) - 1.0).abs() < 1e-9);
+        assert!((roc_auc(&[0.0, 1.0], &[2.0, 3.0]) - 0.0).abs() < 1e-9);
+        assert!((roc_auc(&[1.0, 1.0], &[1.0, 1.0]) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn discrimination_high_when_signal_present() {
+        // Genuinely clean: low noise, no injected interferents. A real peptide
+        // vs pure noise must separate near-perfectly.
+        let mut base = SimParams::default();
+        base.n_cycles = 150;
+        base.noise_floor = 0.05;
+        base.random_peaks.enabled = false;
+        let rep = run_discrimination(&base, 200);
+        assert!(
+            rep.auc > 0.9,
+            "clean signal should separate: auc={}",
+            rep.auc
+        );
+        assert!(rep.median_present > rep.median_absent);
+    }
+}

--- a/rust/apex_sim/src/sim.rs
+++ b/rust/apex_sim/src/sim.rs
@@ -107,6 +107,11 @@ pub struct SimParams {
     pub n_cycles: usize,
     /// Shared apex position (cycle index) for all real fragments + precursor.
     pub apex_cycle: f32,
+    /// When `Some(range)`, each run draws the realized apex from the seeded rng
+    /// as `apex_cycle + U(-range, range) + U(-0.5, 0.5)` (position varies per
+    /// seed AND lands off-grid). `None` pins it exactly to `apex_cycle` (the
+    /// historical, unrealistically-easy on-grid, fixed-position behavior).
+    pub apex_jitter: Option<f32>,
     /// Elution peak width (gaussian sigma, in cycles).
     pub width_sigma: f32,
     /// Global height scale applied on top of each fragment's rel_intensity.
@@ -154,6 +159,7 @@ impl Default for SimParams {
         Self {
             n_cycles: 60,
             apex_cycle: 30.0,
+            apex_jitter: None,
             width_sigma: 1.0,
             height: 1000.0,
             real_fragments,
@@ -192,6 +198,9 @@ pub struct SimData {
     pub extraction: Extraction<String>,
     pub fragment_rows: Vec<TransitionRow>,
     pub precursor_rows: Vec<TransitionRow>,
+    /// The apex cycle actually used to generate this realization (equals
+    /// `apex_cycle` when `apex_jitter` is `None`, else the jittered value).
+    pub realized_apex_cycle: f32,
 }
 
 /// Gaussian elution value at `cycle` for a peak centered at `center`.
@@ -205,6 +214,19 @@ pub fn build(params: &SimParams) -> SimData {
     let mut rng = ChaCha8Rng::seed_from_u64(params.seed);
     let n = params.n_cycles;
     let dummy_mz = 500.0_f64;
+
+    // Realized apex: jittered per-seed + sub-cycle when enabled, else pinned.
+    // Drawn BEFORE any signal/noise sampling; the `None` branch consumes no rng
+    // so historical scenarios stay byte-identical.
+    let realized_apex = match params.apex_jitter {
+        Some(range) => {
+            let lo = 3.0f32;
+            let hi = (n as f32 - 4.0).max(lo);
+            (params.apex_cycle + rng.random_range(-range..=range) + rng.random_range(-0.5..=0.5))
+                .clamp(lo, hi)
+        }
+        None => params.apex_cycle,
+    };
 
     // --- Expected intensities: THEORETICAL (library) ratios. ---
     // These drive cosine/scribe. Observed peaks below may deviate (obs_scale).
@@ -231,7 +253,7 @@ pub fn build(params: &SimParams) -> SimData {
         let noise = params.noise_floor * params.height * f.noise_mult;
         let intensities = (0..n)
             .map(|c| {
-                let signal = gaussian(c as f32, params.apex_cycle, params.width_sigma, peak);
+                let signal = gaussian(c as f32, realized_apex, params.width_sigma, peak);
                 sample_cell(&mut rng, signal, noise)
             })
             .collect();
@@ -251,7 +273,7 @@ pub fn build(params: &SimParams) -> SimData {
         let noise = params.noise_floor * params.height;
         let intensities = (0..n)
             .map(|c| {
-                let signal = gaussian(c as f32, params.apex_cycle, params.width_sigma, peak);
+                let signal = gaussian(c as f32, realized_apex, params.width_sigma, peak);
                 sample_cell(&mut rng, signal, noise)
             })
             .collect();
@@ -291,7 +313,7 @@ pub fn build(params: &SimParams) -> SimData {
     let chromatograms = ChromatogramCollector::<String, f32> {
         id: 0,
         mobility_ook0: 1.0,
-        rt_seconds: (map((params.apex_cycle as usize).min(n - 1)) as f32) / 1000.0,
+        rt_seconds: (map((realized_apex as usize).min(n - 1)) as f32) / 1000.0,
         precursor_mono_mz: dummy_mz,
         precursor_charge: 2,
         precursor_mz_limits: (dummy_mz - 1.0, dummy_mz + 1.0),
@@ -330,6 +352,7 @@ pub fn build(params: &SimParams) -> SimData {
         extraction,
         fragment_rows: frag_rows,
         precursor_rows: prec_rows,
+        realized_apex_cycle: realized_apex,
     }
 }
 
@@ -418,6 +441,27 @@ mod tests {
         q.density_per_cycle = 0.0;
         q.count = 77;
         assert_eq!(effective_random_count(&q, 5000), 77);
+    }
+
+    #[test]
+    fn apex_jitter_is_deterministic_and_subcycle() {
+        let mut p = SimParams::default();
+        p.n_cycles = 200;
+        p.apex_cycle = 100.0;
+        p.apex_jitter = Some(20.0);
+        let a = build(&p).realized_apex_cycle;
+        let b = build(&p).realized_apex_cycle; // same seed => identical
+        assert_eq!(a, b);
+        assert!((a - 100.0).abs() <= 20.5 + 1e-3);
+        // vary seed => different position
+        let mut q = p.clone();
+        q.seed = p.seed.wrapping_add(1);
+        let c = build(&q).realized_apex_cycle;
+        assert!((a - c).abs() > 1e-6);
+        // no jitter => exact
+        let mut r = p.clone();
+        r.apex_jitter = None;
+        assert_eq!(build(&r).realized_apex_cycle, 100.0);
     }
 
     #[test]

--- a/rust/apex_sim/src/sim.rs
+++ b/rust/apex_sim/src/sim.rs
@@ -67,6 +67,14 @@ pub struct RandomPeaks {
     pub height_frac_max: f32,
     /// If true, precursor rows are also eligible targets.
     pub hit_precursors: bool,
+    /// Interferents per cycle; when > 0 this overrides `count` as
+    /// `round(density_per_cycle * n_cycles * hardness)`, so interferent DENSITY
+    /// (not absolute count) stays fixed as the window widens — a fixed count in
+    /// a wide window is an artificially easy task.
+    pub density_per_cycle: f32,
+    /// Multiplier (>=1) to deliberately over-load interferents above realistic
+    /// density for stress-testing.
+    pub hardness: f32,
 }
 
 impl Default for RandomPeaks {
@@ -77,7 +85,19 @@ impl Default for RandomPeaks {
             height_frac_min: 0.1,
             height_frac_max: 10.0,
             hit_precursors: true,
+            density_per_cycle: 0.0,
+            hardness: 1.0,
         }
+    }
+}
+
+/// Effective interferent count for a window of `n_cycles`: density-scaled when
+/// `density_per_cycle > 0`, else the absolute `count`.
+pub fn effective_random_count(rp: &RandomPeaks, n_cycles: usize) -> usize {
+    if rp.density_per_cycle > 0.0 {
+        (rp.density_per_cycle * n_cycles as f32 * rp.hardness.max(1.0)).round() as usize
+    } else {
+        rp.count
     }
 }
 
@@ -323,10 +343,11 @@ fn inject_random_peaks(
     params: &SimParams,
 ) {
     let rp = &params.random_peaks;
-    if !rp.enabled || rp.count == 0 {
+    let n = params.n_cycles;
+    let count = effective_random_count(rp, n);
+    if !rp.enabled || count == 0 {
         return;
     }
-    let n = params.n_cycles;
     let n_frag = frag_rows.len();
     let n_targets = n_frag
         + if rp.hit_precursors {
@@ -338,7 +359,7 @@ fn inject_random_peaks(
         return;
     }
 
-    for _ in 0..rp.count {
+    for _ in 0..count {
         let target = rng.random_range(0..n_targets);
         let row = if target < n_frag {
             &mut frag_rows[target]
@@ -381,6 +402,23 @@ fn fill_array<K: timsquery::KeyLike>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn density_scales_interferent_count_with_window() {
+        let mut p = SimParams::default();
+        p.random_peaks.count = 0;
+        p.random_peaks.density_per_cycle = 2.0;
+        p.random_peaks.hardness = 1.0;
+        assert_eq!(effective_random_count(&p.random_peaks, 100), 200);
+        assert_eq!(effective_random_count(&p.random_peaks, 1000), 2000);
+        p.random_peaks.hardness = 3.0;
+        assert_eq!(effective_random_count(&p.random_peaks, 100), 600);
+        // count path preserved when density is 0
+        let mut q = RandomPeaks::default();
+        q.density_per_cycle = 0.0;
+        q.count = 77;
+        assert_eq!(effective_random_count(&q, 5000), 77);
+    }
 
     #[test]
     fn clean_peak_apex_lands_at_configured_cycle() {


### PR DESCRIPTION
Stacked on #68 (apex-weighting-clean). Bench-only (apex_sim); no timsseek
production changes.

Makes apex_sim benchmark the apex-finder and the score as SEPARATE functions
under production-realistic conditions, and adds a signal-vs-noise score metric.
All additive: existing canonical suite / SimParams behavior preserved by
defaults.

## Why

The old bench conflated two jobs and tested neither the way production runs them:
- Pass 1 (apex finder, weighted apex_profile) runs over a BROAD ~1695-cyc window
  (Phase 1) and inside a NARROW ~150-cyc calibrated window (Phase 3).
- Pass 2 (score / main_score) is meant to separate real signal from noise, but
  the bench only measured apex-cycle recovery, never score magnitude.
It also pinned the apex to an integer index at the SAME position every run, and
used a fixed interferent COUNT (so a wider window = lower density = easier).

## Empirical anchors (derived from a real run)

250225_Desnaux_200ng_Hela ICC_off, default tol. Instrumented the two callsites
+ read a persisted results.parquet (11743 targets at q<0.01):
- broad window (Phase 1): 1695 cycles (RT-unrestricted, whole gradient).
- narrow window (Phase 3): 82-206 cycles, median 152.
- peak width: rising/falling ~3 cyc => sigma ~1 (sim's 1.0 already realistic).

## Changes

1. Density-scaled interferents: `RandomPeaks.density_per_cycle` (+ `hardness`)
   => count = round(density * n_cycles * hardness). Fixed density as the window
   grows; `hardness>1` over-loads on purpose. `count` path preserved.
2. Sub-cycle apex jitter: `SimParams.apex_jitter=Some(range)` draws the realized
   apex = apex_cycle + U(-range,range) + U(-0.5,0.5) per seed (off-grid, moving
   target); `SimData.realized_apex_cycle` reports it and run_sensitivity scores
   against it. `None` keeps the historical on-grid fixed apex byte-identical.
3. ROC-AUC discrimination: `run_discrimination` scores matched present/absent
   pairs (absent = all fragments AND precursor zeroed, same seed => identical
   noise+interferents) and reports ROC-AUC of the Pass-2 main_score.
4. Realistic suites: broad_suite (1695 cyc) + narrow_suite (150 cyc), density
   0.41/cyc (= canonical 100/245, so window size is the only changed variable),
   jittered apex, per-scenario stressors incl a 3x-density hard variant.
5. Example prints canonical / broad / narrow recovery tables + a narrow AUC
   table. Canonical header kept as `=== summary` so bench_out/score.sh still
   parses it. Each scenario is its own line (comment out to disable).

## Results (n=2000, broad n=500, tol +/-2)

Same density, wider window is measurably harder:

  high_noise+interf   canonical 245cyc 86%   broad 1695cyc 54%   narrow 150cyc 90%
  mismatched          canonical        88%   broad         59%   narrow        93%

hard_3x_density (1.23/cyc) collapses recovery to ~0-8% (explicit stressor).

Score discrimination (narrow AUC, present vs pure noise):

  clean 1.000   moderate 0.870   high_noise 0.840   mismatched 0.876   hard 0.680

med(present) > med(absent) in every scenario. The score separates well until
interference piles up, then degrades to ~0.68 -- the axis the old bench could
not see.

## Follow-up (out of scope, bench-first)

Pass-2 apex relocation: score_at computes effective_apex from find_joint_apex on
the UN-weighted cosine_profile (global argmax), which drifts onto interferents
in narrow windows. The narrow-recovery + AUC metrics here exist to prove that
fix when it lands.

## Validation

- cargo test -p apex_sim: 11 passed (density scaling, jitter determinism/sub-
  cycle, roc_auc, discrimination).
- cargo build -p apex_sim --release: clean.
- Full bench: bench_out/logs/realistic-bench-v2.log.
- Note: apex_sim has a pre-existing clippy field_reassign_with_default idiom in
  the suite base() closures; the new suites follow it for consistency.
