### PR TITLE
[WIP] rescore: LDA path + env-tunable GBM config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ plot_calib.py
 LEARNINGS.md
 research.md
 reading.md
+
+# Local bench outputs, logs, feature dumps (repo-local, never tracked)
+bench_out/

--- a/rust/timsseek/src/ml/cv.rs
+++ b/rust/timsseek/src/ml/cv.rs
@@ -136,6 +136,49 @@ impl Clone for GBMConfig {
     }
 }
 
+impl GBMConfig {
+    /// Start from `default()` and apply optional env overrides so the
+    /// accuracy/speed knob can be swept on the real pipeline without recompiling:
+    ///   TIMSSEEK_GBM_ITERS, TIMSSEEK_GBM_MAX_DEPTH, TIMSSEEK_GBM_MAX_LEAVES,
+    ///   TIMSSEEK_GBM_LR, TIMSSEEK_GBM_EARLY_STOP.
+    /// A slashed config (fewer/shallower trees) trades a small ID loss for a
+    /// large wall-clock win — the offline HistGBM sweep put ~100 it / ~15 leaves
+    /// at ~94% of the full-config IDs.
+    pub fn from_env() -> Self {
+        fn env<T: std::str::FromStr>(k: &str) -> Option<T> {
+            std::env::var(k).ok().and_then(|v| v.parse().ok())
+        }
+        let mut c = Self::default();
+        if let Some(v) = env("TIMSSEEK_GBM_ITERS") {
+            c.iterations = v;
+        }
+        if let Some(v) = env("TIMSSEEK_GBM_MAX_DEPTH") {
+            c.max_depth = v;
+        }
+        if let Some(v) = env::<usize>("TIMSSEEK_GBM_MAX_LEAVES") {
+            c.max_leaves = v;
+            // Leaf-count caps only bite under loss-guided growth.
+            c.grow_policy = GrowPolicy::LossGuide;
+        }
+        if let Some(v) = env("TIMSSEEK_GBM_LR") {
+            c.learning_rate = v;
+        }
+        if let Some(v) = env("TIMSSEEK_GBM_EARLY_STOP") {
+            c.early_stopping_rounds = Some(v);
+        }
+        if std::env::var("TIMSSEEK_GBM_ITERS").is_ok()
+            || std::env::var("TIMSSEEK_GBM_MAX_LEAVES").is_ok()
+            || std::env::var("TIMSSEEK_GBM_MAX_DEPTH").is_ok()
+        {
+            eprintln!(
+                "  GBM config: iters={} max_depth={} max_leaves={} lr={} early_stop={:?}",
+                c.iterations, c.max_depth, c.max_leaves, c.learning_rate, c.early_stopping_rounds,
+            );
+        }
+        c
+    }
+}
+
 impl Default for GBMConfig {
     fn default() -> Self {
         GBMConfig {

--- a/rust/timsseek/src/ml/lda.rs
+++ b/rust/timsseek/src/ml/lda.rs
@@ -1,0 +1,670 @@
+//! Shrinkage Linear Discriminant Analysis rescorer.
+//!
+//! Sage-style two-class Fisher LDA (github.com/lazear/sage), adapted for the
+//! timsseek feature set. Differences from Sage:
+//!   * Features are z-standardized (mean/std over the training rows) before the
+//!     fit. Sage skips this because exact Fisher LDA is scale-invariant; we add
+//!     ridge shrinkage below, which is NOT scale-invariant, so standardization
+//!     is required to make the `lambda * I` term comparable across features.
+//!   * The within-class scatter is ridge-regularized (`Sw + lambda*I`). The
+//!     timsseek feature set (~108 dims) is heavily collinear (main_score family,
+//!     the 7 per-ion error dims + their mean, 22 AA counts, ...), which makes
+//!     the raw `Sw` near-singular. Shrinkage keeps the linear solve stable
+//!     without hand-pruning the feature set, so LDA sees the exact same inputs
+//!     as the GBM path (clean apples-to-apples bench).
+//!   * NaN/non-finite feature values are imputed to the column mean (i.e. 0
+//!     after standardization). The GBM handles missing natively; LDA cannot.
+//!
+//! For two-class LDA the between-class scatter is rank-1 along `(mu_t - mu_d)`,
+//! so the discriminant direction is `w = (Sw + lambda*I)^-1 (mu_t - mu_d)`.
+//! Target rows project higher than decoy rows by construction.
+//!
+//! # Layout & scaling
+//! The feature matrix is a single flat row-major `Vec<f64>` (`feat[i*d + j]`),
+//! never a `Vec<Vec<f64>>` — at tens of millions of candidates the per-row
+//! allocation and pointer-chasing dominate. The two heavy costs are both
+//! **linear in the row count but with large constants**, and both are
+//! parallelized (deterministically) over rayon:
+//!   * within-class scatter — `O(n * d^2)` (`d^2 ~ 11.6k` FMAs/row);
+//!   * inverse-normal transform — `O(d * n log n)` (`d` column sorts).
+//! Nothing here is super-linear in `n`.
+
+use std::time::Instant;
+
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+
+/// Fraction of `mean(diag(Sw))` added to the diagonal as ridge shrinkage.
+/// Small enough to barely perturb a well-conditioned problem, large enough to
+/// rescue a rank-deficient one.
+const DEFAULT_SHRINKAGE: f64 = 1e-2;
+
+/// Row-chunk size for the parallel reductions. Fixed so chunk boundaries — and
+/// therefore the summation order of the partial accumulators — are identical
+/// across runs, keeping the fit bitwise-deterministic despite parallelism.
+const CHUNK_ROWS: usize = 65_536;
+
+pub struct LdaModel {
+    /// Discriminant direction in standardized feature space.
+    coef: Vec<f64>,
+    /// Per-feature standardization mean (finite-only).
+    mean: Vec<f64>,
+    /// Per-feature standardization std (finite-only, floored so near-constant
+    /// features standardize to ~0 rather than exploding).
+    inv_std: Vec<f64>,
+    ncols: usize,
+}
+
+impl LdaModel {
+    /// Fit LDA from a flat row-major feature matrix (`feat[i*ncols + j]`) and
+    /// boolean decoy labels (`is_decoy[i]`).
+    ///
+    /// Returns `None` if either class is empty or the linear solve is singular
+    /// even after shrinkage.
+    pub fn fit(
+        feat: &[f64],
+        nrows: usize,
+        ncols: usize,
+        is_decoy: &[bool],
+        shrinkage: f64,
+    ) -> Option<LdaModel> {
+        assert_eq!(is_decoy.len(), nrows);
+        assert_eq!(feat.len(), nrows * ncols);
+        if nrows == 0 || ncols == 0 {
+            return None;
+        }
+
+        // --- Standardization stats (finite values only), parallel reduce ---
+        let t = Instant::now();
+        let (sum, sumsq, cnt) = col_finite_moments(feat, nrows, ncols);
+        let mut mean = vec![0.0f64; ncols];
+        let mut inv_std = vec![1.0f64; ncols];
+        for j in 0..ncols {
+            if cnt[j] > 0 {
+                let n = cnt[j] as f64;
+                let m = sum[j] / n;
+                let var = (sumsq[j] / n - m * m).max(0.0);
+                let std = var.sqrt();
+                mean[j] = m;
+                inv_std[j] = if std > 1e-12 { 1.0 / std } else { 0.0 };
+            }
+        }
+
+        // --- Pass 1: per-class means in standardized space (parallel) ---
+        let (class_sum, class_cnt) = class_std_sums(feat, nrows, ncols, is_decoy, &mean, &inv_std);
+        if class_cnt[0] == 0 || class_cnt[1] == 0 {
+            return None;
+        }
+        let class_mean: [Vec<f64>; 2] = std::array::from_fn(|c| {
+            let n = class_cnt[c] as f64;
+            (0..ncols).map(|j| class_sum[c][j] / n).collect()
+        });
+        eprintln!(
+            "  LDA: standardized + class means ({nrows} rows x {ncols} feats) in {:.2?}",
+            t.elapsed()
+        );
+
+        // --- Pass 2: pooled within-class scatter Sw (parallel, D x D) ---
+        // Sw = sum_c (1/n_c) sum_{i in c} (z_i - mu_c)(z_i - mu_c)^T
+        let t = Instant::now();
+        let mut sw =
+            within_class_scatter(feat, nrows, ncols, is_decoy, &mean, &inv_std, &class_mean);
+        for c in 0..2 {
+            let inv_nc = 1.0 / class_cnt[c] as f64;
+            let off = c * ncols * ncols;
+            for e in &mut sw[off..off + ncols * ncols] {
+                *e *= inv_nc;
+            }
+        }
+        // Fold the two per-class scatters into one within-class matrix.
+        let mut sw_within = vec![0.0f64; ncols * ncols];
+        for e in 0..ncols * ncols {
+            sw_within[e] = sw[e] + sw[ncols * ncols + e];
+        }
+        eprintln!("  LDA: within-class scatter in {:.2?}", t.elapsed());
+
+        // --- Ridge shrinkage: Sw += lambda_eff * I ---
+        let mut diag_sum = 0.0f64;
+        for j in 0..ncols {
+            diag_sum += sw_within[j * ncols + j];
+        }
+        let lambda_eff = shrinkage * (diag_sum / ncols as f64).max(1e-12);
+        for j in 0..ncols {
+            sw_within[j * ncols + j] += lambda_eff;
+        }
+
+        // --- Solve Sw * w = (mu_t - mu_d) ---
+        let mu_diff: Vec<f64> = (0..ncols)
+            .map(|j| class_mean[1][j] - class_mean[0][j])
+            .collect();
+        let coef = solve_gauss(sw_within, mu_diff, ncols)?;
+        if !coef.iter().all(|c| c.is_finite()) {
+            return None;
+        }
+
+        Some(LdaModel {
+            coef,
+            mean,
+            inv_std,
+            ncols,
+        })
+    }
+
+    /// Project one raw (un-standardized) feature row onto the discriminant.
+    pub fn score(&self, row: &[f64]) -> f64 {
+        debug_assert_eq!(row.len(), self.ncols);
+        let mut acc = 0.0;
+        for j in 0..self.ncols {
+            let v = row[j];
+            let z = if v.is_finite() {
+                (v - self.mean[j]) * self.inv_std[j]
+            } else {
+                0.0
+            };
+            acc += self.coef[j] * z;
+        }
+        acc
+    }
+
+    /// Score every row of a flat row-major matrix (parallel), into `out`.
+    pub fn score_all(&self, feat: &[f64], nrows: usize, out: &mut [f64]) {
+        let d = self.ncols;
+        assert_eq!(feat.len(), nrows * d);
+        assert_eq!(out.len(), nrows);
+        #[cfg(feature = "rayon")]
+        {
+            out.par_iter_mut()
+                .enumerate()
+                .for_each(|(i, o)| *o = self.score(&feat[i * d..(i + 1) * d]));
+        }
+        #[cfg(not(feature = "rayon"))]
+        {
+            for (i, o) in out.iter_mut().enumerate() {
+                *o = self.score(&feat[i * d..(i + 1) * d]);
+            }
+        }
+    }
+
+    /// Discriminant weights in standardized space, `|coef|`-interpretable as
+    /// feature importance.
+    pub fn coef(&self) -> &[f64] {
+        &self.coef
+    }
+}
+
+/// Per-column finite sum / sum-of-squares / count, reduced over fixed row
+/// chunks (deterministic summation order).
+fn col_finite_moments(feat: &[f64], nrows: usize, ncols: usize) -> (Vec<f64>, Vec<f64>, Vec<u64>) {
+    let chunk = CHUNK_ROWS * ncols;
+    let fold = |acc: &mut (Vec<f64>, Vec<f64>, Vec<u64>), block: &[f64]| {
+        for row in block.chunks_exact(ncols) {
+            for j in 0..ncols {
+                let v = row[j];
+                if v.is_finite() {
+                    acc.0[j] += v;
+                    acc.1[j] += v * v;
+                    acc.2[j] += 1;
+                }
+            }
+        }
+    };
+    let zero = || (vec![0.0f64; ncols], vec![0.0f64; ncols], vec![0u64; ncols]);
+
+    #[cfg(feature = "rayon")]
+    let partials: Vec<(Vec<f64>, Vec<f64>, Vec<u64>)> = feat
+        .par_chunks(chunk)
+        .map(|block| {
+            let mut acc = zero();
+            fold(&mut acc, block);
+            acc
+        })
+        .collect();
+    #[cfg(not(feature = "rayon"))]
+    let partials: Vec<(Vec<f64>, Vec<f64>, Vec<u64>)> = feat
+        .chunks(chunk)
+        .map(|block| {
+            let mut acc = zero();
+            fold(&mut acc, block);
+            acc
+        })
+        .collect();
+
+    let mut out = zero();
+    for (s, sq, c) in &partials {
+        for j in 0..ncols {
+            out.0[j] += s[j];
+            out.1[j] += sq[j];
+            out.2[j] += c[j];
+        }
+    }
+    let _ = nrows;
+    out
+}
+
+/// Per-class standardized-feature sums + counts (parallel, deterministic).
+fn class_std_sums(
+    feat: &[f64],
+    nrows: usize,
+    ncols: usize,
+    is_decoy: &[bool],
+    mean: &[f64],
+    inv_std: &[f64],
+) -> ([Vec<f64>; 2], [u64; 2]) {
+    let chunk_rows = CHUNK_ROWS;
+    let std_at = |row: &[f64], j: usize| {
+        let v = row[j];
+        if v.is_finite() {
+            (v - mean[j]) * inv_std[j]
+        } else {
+            0.0
+        }
+    };
+    let per_chunk = |ci: usize| {
+        let r0 = ci * chunk_rows;
+        let r1 = ((ci + 1) * chunk_rows).min(nrows);
+        let mut csum = [vec![0.0f64; ncols], vec![0.0f64; ncols]];
+        let mut ccnt = [0u64; 2];
+        for i in r0..r1 {
+            let row = &feat[i * ncols..(i + 1) * ncols];
+            let c = if is_decoy[i] { 0 } else { 1 };
+            for j in 0..ncols {
+                csum[c][j] += std_at(row, j);
+            }
+            ccnt[c] += 1;
+        }
+        (csum, ccnt)
+    };
+    let nchunks = nrows.div_ceil(chunk_rows);
+
+    #[cfg(feature = "rayon")]
+    let partials: Vec<([Vec<f64>; 2], [u64; 2])> =
+        (0..nchunks).into_par_iter().map(per_chunk).collect();
+    #[cfg(not(feature = "rayon"))]
+    let partials: Vec<([Vec<f64>; 2], [u64; 2])> = (0..nchunks).map(per_chunk).collect();
+
+    let mut class_sum = [vec![0.0f64; ncols], vec![0.0f64; ncols]];
+    let mut class_cnt = [0u64; 2];
+    for (csum, ccnt) in &partials {
+        for c in 0..2 {
+            for j in 0..ncols {
+                class_sum[c][j] += csum[c][j];
+            }
+            class_cnt[c] += ccnt[c];
+        }
+    }
+    (class_sum, class_cnt)
+}
+
+/// Per-class within-class scatter (un-normalized), returned as two stacked
+/// row-major `D x D` blocks: `[class0 (D*D), class1 (D*D)]`. Reduced over fixed
+/// row chunks for determinism. This is the `O(n * d^2)` hot loop.
+fn within_class_scatter(
+    feat: &[f64],
+    nrows: usize,
+    ncols: usize,
+    is_decoy: &[bool],
+    mean: &[f64],
+    inv_std: &[f64],
+    class_mean: &[Vec<f64>; 2],
+) -> Vec<f64> {
+    let chunk_rows = CHUNK_ROWS;
+    let dd = ncols * ncols;
+    let per_chunk = |ci: usize| -> Vec<f64> {
+        let r0 = ci * chunk_rows;
+        let r1 = ((ci + 1) * chunk_rows).min(nrows);
+        let mut out = vec![0.0f64; 2 * dd];
+        let mut centered = vec![0.0f64; ncols];
+        for i in r0..r1 {
+            let row = &feat[i * ncols..(i + 1) * ncols];
+            let c = if is_decoy[i] { 0 } else { 1 };
+            let mu = &class_mean[c];
+            for j in 0..ncols {
+                let v = row[j];
+                let z = if v.is_finite() {
+                    (v - mean[j]) * inv_std[j]
+                } else {
+                    0.0
+                };
+                centered[j] = z - mu[j];
+            }
+            let base = c * dd;
+            for j in 0..ncols {
+                let cj = centered[j];
+                if cj == 0.0 {
+                    continue;
+                }
+                let rowbase = base + j * ncols;
+                for k in 0..ncols {
+                    out[rowbase + k] += cj * centered[k];
+                }
+            }
+        }
+        out
+    };
+    let nchunks = nrows.div_ceil(chunk_rows);
+
+    #[cfg(feature = "rayon")]
+    let partials: Vec<Vec<f64>> = (0..nchunks).into_par_iter().map(per_chunk).collect();
+    #[cfg(not(feature = "rayon"))]
+    let partials: Vec<Vec<f64>> = (0..nchunks).map(per_chunk).collect();
+
+    let mut sw = vec![0.0f64; 2 * dd];
+    for p in &partials {
+        for e in 0..2 * dd {
+            sw[e] += p[e];
+        }
+    }
+    sw
+}
+
+/// Solve `A x = b` for a row-major `n x n` matrix `A` via Gaussian elimination
+/// with partial pivoting. Returns `None` if `A` is singular. `A` and `b` are
+/// consumed (used as scratch).
+fn solve_gauss(mut a: Vec<f64>, mut b: Vec<f64>, n: usize) -> Option<Vec<f64>> {
+    for col in 0..n {
+        // Partial pivot: largest magnitude in this column at/below the diagonal.
+        let mut pivot = col;
+        let mut best = a[col * n + col].abs();
+        for r in (col + 1)..n {
+            let v = a[r * n + col].abs();
+            if v > best {
+                best = v;
+                pivot = r;
+            }
+        }
+        if best < 1e-12 {
+            return None;
+        }
+        if pivot != col {
+            for k in 0..n {
+                a.swap(col * n + k, pivot * n + k);
+            }
+            b.swap(col, pivot);
+        }
+        // Eliminate below.
+        let diag = a[col * n + col];
+        for r in (col + 1)..n {
+            let factor = a[r * n + col] / diag;
+            if factor == 0.0 {
+                continue;
+            }
+            for k in col..n {
+                a[r * n + k] -= factor * a[col * n + k];
+            }
+            b[r] -= factor * b[col];
+        }
+    }
+    // Back-substitution.
+    let mut x = vec![0.0f64; n];
+    for col in (0..n).rev() {
+        let mut acc = b[col];
+        for k in (col + 1)..n {
+            acc -= a[col * n + k] * x[k];
+        }
+        x[col] = acc / a[col * n + col];
+    }
+    Some(x)
+}
+
+/// Send+Sync wrapper around a raw `*mut f64` so disjoint columns of the flat
+/// feature matrix can be transformed in parallel. Safe because each column `j`
+/// touches only the strided index set `{i*ncols + j}`, which is disjoint across
+/// distinct `j`.
+#[cfg(feature = "rayon")]
+struct ColPtr(*mut f64);
+#[cfg(feature = "rayon")]
+unsafe impl Sync for ColPtr {}
+
+/// Rank-based inverse-normal transform (van der Waerden). Rewrites each column
+/// of a flat row-major `nrows x ncols` matrix so its finite values become
+/// marginally ~N(0,1): rank -> `Phi^-1((rank - 0.5) / n_finite)`. This is the
+/// distribution-free way to satisfy the LDA per-feature normality assumption
+/// without knowing each feature's range (bounded correlations, heavy-tail
+/// scores, discrete counts all get Gaussianized uniformly). Non-finite values
+/// are left as-is (imputed downstream). Ties get averaged ranks.
+///
+/// Label-blind, so it is applied once to the whole dataset with no target/decoy
+/// leakage. Parallel over columns (`O(d * n log n)`).
+pub fn inverse_normal_transform_columns(feat: &mut [f64], nrows: usize, ncols: usize) {
+    if nrows == 0 {
+        return;
+    }
+    assert_eq!(feat.len(), nrows * ncols);
+
+    #[cfg(feature = "rayon")]
+    {
+        let base = ColPtr(feat.as_mut_ptr());
+        (0..ncols).into_par_iter().for_each(|j| {
+            // SAFETY: column `j` accesses only indices `i*ncols + j` for
+            // `i in 0..nrows`; these sets are disjoint across `j`, so parallel
+            // columns never alias.
+            let base = &base;
+            let get = |i: usize| unsafe { *base.0.add(i * ncols + j) };
+            let set = |i: usize, v: f64| unsafe { *base.0.add(i * ncols + j) = v };
+            int_one_column(nrows, get, set);
+        });
+    }
+    #[cfg(not(feature = "rayon"))]
+    {
+        for j in 0..ncols {
+            let get = |i: usize| feat[i * ncols + j];
+            let mut vals: Vec<(usize, f64)> = Vec::new();
+            int_one_column_serial(nrows, get, &mut vals, |i, v| feat[i * ncols + j] = v);
+        }
+    }
+}
+
+/// INT for a single column addressed via `get`/`set` closures.
+#[cfg(feature = "rayon")]
+fn int_one_column(nrows: usize, get: impl Fn(usize) -> f64, set: impl Fn(usize, f64)) {
+    let mut order: Vec<usize> = (0..nrows).filter(|&i| get(i).is_finite()).collect();
+    let nf = order.len();
+    if nf == 0 {
+        return;
+    }
+    order.sort_unstable_by(|&a, &b| get(a).partial_cmp(&get(b)).unwrap());
+    let nf_f = nf as f64;
+    let mut i = 0usize;
+    while i < nf {
+        let vi = get(order[i]);
+        let mut k = i + 1;
+        while k < nf && get(order[k]) == vi {
+            k += 1;
+        }
+        let avg_rank = (i + k - 1) as f64 / 2.0;
+        let z = inverse_normal_cdf((avg_rank + 0.5) / nf_f);
+        for &idx in &order[i..k] {
+            set(idx, z);
+        }
+        i = k;
+    }
+}
+
+/// Serial-fallback INT for a single column (no rayon feature).
+#[cfg(not(feature = "rayon"))]
+fn int_one_column_serial(
+    nrows: usize,
+    get: impl Fn(usize) -> f64,
+    scratch: &mut Vec<(usize, f64)>,
+    mut set: impl FnMut(usize, f64),
+) {
+    scratch.clear();
+    scratch.extend((0..nrows).filter_map(|i| {
+        let v = get(i);
+        if v.is_finite() { Some((i, v)) } else { None }
+    }));
+    let nf = scratch.len();
+    if nf == 0 {
+        return;
+    }
+    scratch.sort_unstable_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    let nf_f = nf as f64;
+    let mut i = 0usize;
+    while i < nf {
+        let vi = scratch[i].1;
+        let mut k = i + 1;
+        while k < nf && scratch[k].1 == vi {
+            k += 1;
+        }
+        let avg_rank = (i + k - 1) as f64 / 2.0;
+        let z = inverse_normal_cdf((avg_rank + 0.5) / nf_f);
+        for m in i..k {
+            set(scratch[m].0, z);
+        }
+        i = k;
+    }
+}
+
+/// Acklam's rational approximation to the standard normal quantile function.
+/// Absolute error < 1.15e-9 across (0,1).
+fn inverse_normal_cdf(p: f64) -> f64 {
+    const A: [f64; 6] = [
+        -3.969683028665376e+01,
+        2.209460984245205e+02,
+        -2.759285104469687e+02,
+        1.383577518672690e+02,
+        -3.066479806614716e+01,
+        2.506628277459239e+00,
+    ];
+    const B: [f64; 5] = [
+        -5.447609879822406e+01,
+        1.615858368580409e+02,
+        -1.556989798598866e+02,
+        6.680131188771972e+01,
+        -1.328068155288572e+01,
+    ];
+    const C: [f64; 6] = [
+        -7.784894002430293e-03,
+        -3.223964580411365e-01,
+        -2.400758277161838e+00,
+        -2.549732539343734e+00,
+        4.374664141464968e+00,
+        2.938163982698783e+00,
+    ];
+    const D: [f64; 4] = [
+        7.784695709041462e-03,
+        3.224671290700398e-01,
+        2.445134137142996e+00,
+        3.754408661907416e+00,
+    ];
+    const P_LOW: f64 = 0.02425;
+    let p = p.clamp(1e-12, 1.0 - 1e-12);
+    if p < P_LOW {
+        let q = (-2.0 * p.ln()).sqrt();
+        (((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
+            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
+    } else if p <= 1.0 - P_LOW {
+        let q = p - 0.5;
+        let r = q * q;
+        (((((A[0] * r + A[1]) * r + A[2]) * r + A[3]) * r + A[4]) * r + A[5]) * q
+            / (((((B[0] * r + B[1]) * r + B[2]) * r + B[3]) * r + B[4]) * r + 1.0)
+    } else {
+        let q = (-2.0 * (1.0 - p).ln()).sqrt();
+        -(((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
+            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Row-major flat helper for tests.
+    fn flat(rows: &[Vec<f64>]) -> (Vec<f64>, usize, usize) {
+        let nrows = rows.len();
+        let ncols = rows.first().map(|r| r.len()).unwrap_or(0);
+        let mut v = Vec::with_capacity(nrows * ncols);
+        for r in rows {
+            v.extend_from_slice(r);
+        }
+        (v, nrows, ncols)
+    }
+
+    #[test]
+    fn solve_identity() {
+        let a = vec![2.0, 1.0, 1.0, 3.0];
+        let b = vec![3.0, 5.0];
+        let x = solve_gauss(a, b, 2).unwrap();
+        assert!((x[0] - 0.8).abs() < 1e-9, "{x:?}");
+        assert!((x[1] - 1.4).abs() < 1e-9, "{x:?}");
+    }
+
+    #[test]
+    fn singular_returns_none() {
+        let a = vec![1.0, 2.0, 2.0, 4.0];
+        let b = vec![1.0, 2.0];
+        assert!(solve_gauss(a, b, 2).is_none());
+    }
+
+    #[test]
+    fn probit_known_values() {
+        assert!(inverse_normal_cdf(0.5).abs() < 1e-9);
+        assert!((inverse_normal_cdf(0.975) - 1.959963985).abs() < 1e-6);
+        assert!((inverse_normal_cdf(0.025) + 1.959963985).abs() < 1e-6);
+    }
+
+    #[test]
+    fn int_gaussianizes_and_is_monotone() {
+        let rows: Vec<Vec<f64>> = (0..1000)
+            .map(|i| vec![(i as f64).exp() % 1e6, (i as f64) / 1000.0])
+            .collect();
+        let (mut feat, nrows, ncols) = flat(&rows);
+        inverse_normal_transform_columns(&mut feat, nrows, ncols);
+        // Monotone in column 1 (was strictly increasing).
+        for i in 1..nrows {
+            assert!(
+                feat[i * ncols + 1] >= feat[(i - 1) * ncols + 1] - 1e-9,
+                "INT broke monotonicity"
+            );
+        }
+        let m: f64 = (0..nrows).map(|i| feat[i * ncols + 1]).sum::<f64>() / nrows as f64;
+        assert!(m.abs() < 1e-6, "INT column mean {m} not ~0");
+    }
+
+    #[test]
+    fn separable_two_class() {
+        let mut rows = Vec::new();
+        let mut labels = Vec::new();
+        for i in 0..200 {
+            let f = (i % 10) as f64 * 0.1;
+            rows.push(vec![3.0 + f, 3.0 - f]);
+            labels.push(false); // target
+            rows.push(vec![0.0 + f, 0.0 - f]);
+            labels.push(true); // decoy
+        }
+        let (feat, nrows, ncols) = flat(&rows);
+        let lda = LdaModel::fit(&feat, nrows, ncols, &labels, DEFAULT_SHRINKAGE).unwrap();
+        let mut t_sum = 0.0;
+        let mut d_sum = 0.0;
+        for (i, &d) in labels.iter().enumerate() {
+            let s = lda.score(&feat[i * ncols..(i + 1) * ncols]);
+            if d {
+                d_sum += s;
+            } else {
+                t_sum += s;
+            }
+        }
+        assert!(
+            t_sum > d_sum,
+            "targets {t_sum} should exceed decoys {d_sum}"
+        );
+    }
+
+    #[test]
+    fn nan_imputed_not_propagated() {
+        let rows = vec![
+            vec![1.0, f64::NAN],
+            vec![2.0, 1.0],
+            vec![3.0, 2.0],
+            vec![0.0, f64::NAN],
+        ];
+        let labels = vec![false, false, true, true];
+        let (feat, nrows, ncols) = flat(&rows);
+        let lda = LdaModel::fit(&feat, nrows, ncols, &labels, DEFAULT_SHRINKAGE).unwrap();
+        for i in 0..nrows {
+            assert!(lda.score(&feat[i * ncols..(i + 1) * ncols]).is_finite());
+        }
+    }
+}
+
+pub const DEFAULT_LDA_SHRINKAGE: f64 = DEFAULT_SHRINKAGE;

--- a/rust/timsseek/src/ml/mod.rs
+++ b/rust/timsseek/src/ml/mod.rs
@@ -1,7 +1,11 @@
 pub mod cv;
+pub mod lda;
 pub mod qvalues;
 pub use cv::RescoreFeatureStats;
-pub use qvalues::rescore;
+pub use qvalues::{
+    rescore,
+    rescore_lda,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TargetDecoy {

--- a/rust/timsseek/src/ml/qvalues.rs
+++ b/rust/timsseek/src/ml/qvalues.rs
@@ -2,8 +2,15 @@ use super::cv::{
     CrossValidatedScorer,
     DataBuffer,
     FeatureLike,
+    FeatureStat,
+    FoldStats,
     GBMConfig,
     RescoreFeatureStats,
+};
+use super::lda::{
+    DEFAULT_LDA_SHRINKAGE,
+    LdaModel,
+    inverse_normal_transform_columns,
 };
 use super::{
     LabelledScore,
@@ -92,7 +99,7 @@ pub fn report_qvalues_at_thresholds<T: LabelledScore + std::fmt::Debug>(
 const RESCORE_SHUFFLE_SEED: u64 = 42;
 
 pub fn rescore(mut data: Vec<CompetedCandidate>) -> (Vec<FinalResult>, RescoreFeatureStats) {
-    let config = GBMConfig::default();
+    let config = GBMConfig::from_env();
 
     // Canonicalize input order before the seeded shuffle. Upstream
     // stages can emit candidates in an order that drifts with
@@ -132,6 +139,294 @@ pub fn rescore(mut data: Vec<CompetedCandidate>) -> (Vec<FinalResult>, RescoreFe
     debug!("Worst:\n{:#?}", scored.last());
 
     (scored.into_iter().map(|c| c.into_final()).collect(), stats)
+}
+
+/// Sage-style shrinkage-LDA rescorer. Single closed-form linear fit over all
+/// candidates (no CV, no boosting): ~100x cheaper than the GBM path. The FDR
+/// machinery (`assign_qval`, target-decoy competition) is untouched — only the
+/// discriminant score source changes.
+///
+/// Selected at runtime via `TIMSSEEK_RESCORE_MODEL=lda`; the GBM `rescore`
+/// remains the default. See `ml::lda` for the fit details.
+pub fn rescore_lda(mut data: Vec<CompetedCandidate>) -> (Vec<FinalResult>, RescoreFeatureStats) {
+    use std::time::Instant;
+
+    // Same canonical ordering as the GBM path for run-to-run determinism.
+    data.sort_unstable_by_key(|c| (c.scoring.library_id, c.scoring.precursor_charge));
+
+    let base_names: Vec<&'static str> = data.first().map(|c| c.feature_names()).unwrap_or_default();
+    let base_ncols = base_names.len();
+    let nrows = data.len();
+
+    // Materialize the base feature matrix once as a single flat row-major buffer
+    // (`feat[i*ncols + j]`) — a `Vec<Vec<f64>>` here means one heap allocation
+    // per candidate, which dominates at tens of millions of rows. Track finite
+    // counts per column so we can encode informative missingness below.
+    let t = Instant::now();
+    let mut base: Vec<f64> = Vec::with_capacity(nrows * base_ncols);
+    for c in data.iter() {
+        base.extend(c.as_feature());
+    }
+    debug_assert_eq!(base.len(), nrows * base_ncols);
+    let is_decoy: Vec<bool> = data.iter().map(|c| c.get_y() < 0.5).collect();
+
+    // Optional raw-matrix dump for offline feature-engineering iteration.
+    // `TIMSSEEK_LDA_DUMP=/prefix` writes `<prefix>.f64` (row-major matrix),
+    // `<prefix>.labels` (u8, 1=target), `<prefix>.names.txt`. Pre-transform.
+    if let Ok(prefix) = std::env::var("TIMSSEEK_LDA_DUMP") {
+        dump_feature_matrix(&prefix, &base, nrows, &base_names, &is_decoy);
+    }
+
+    // Center-is-better -> monotone-is-better. Signed mass/mobility/RT errors are
+    // best near zero and bad in *either* tail. A linear discriminant assigns one
+    // sign per feature, so it cannot express "close to zero is good" and drives
+    // these ~22 high-value features to ~0 weight (GBM splits on |err| instead).
+    // Fold each to its magnitude so small error becomes a monotone extreme.
+    // Default on; `TIMSSEEK_LDA_ABS=none` disables.
+    let use_abs = std::env::var("TIMSSEEK_LDA_ABS")
+        .map(|v| !v.eq_ignore_ascii_case("none"))
+        .unwrap_or(true);
+    if use_abs {
+        absolutize_center_better(&mut base, base_ncols, &base_names);
+    }
+
+    // Missingness indicators. GBM handles NaN natively (a missing branch), and
+    // absence of higher-index fragment ions correlates with target/decoy. LDA
+    // imputes NaN -> mean, discarding that signal, so we hand it back as binary
+    // `<feat>_isna` columns for every feature whose missing rate is informative
+    // (neither ~always-present nor ~always-absent). Default on;
+    // `TIMSSEEK_LDA_INDICATORS=none` disables.
+    let use_indicators = std::env::var("TIMSSEEK_LDA_INDICATORS")
+        .map(|v| !v.eq_ignore_ascii_case("none"))
+        .unwrap_or(true);
+    let (feat, names, ncols) = if use_indicators {
+        let (feat, names) = augment_with_missingness(&base, nrows, &base_names);
+        let ncols = names.len();
+        (feat, names, ncols)
+    } else {
+        (base, base_names, base_ncols)
+    };
+    eprintln!(
+        "  LDA: extracted {nrows} x {ncols} feature matrix ({} missingness cols) in {:.2?}",
+        ncols - base_ncols,
+        t.elapsed()
+    );
+    let mut feat = feat;
+
+    // Gaussianize each feature toward the LDA normality assumption. Default on;
+    // `TIMSSEEK_LDA_TRANSFORM=none` disables for A/B comparison.
+    let use_int = std::env::var("TIMSSEEK_LDA_TRANSFORM")
+        .map(|v| !v.eq_ignore_ascii_case("none"))
+        .unwrap_or(true);
+    if use_int {
+        let t = Instant::now();
+        inverse_normal_transform_columns(&mut feat, nrows, ncols);
+        eprintln!(
+            "  LDA: inverse-normal transform ({ncols} cols) in {:.2?}",
+            t.elapsed()
+        );
+    }
+
+    let stats = match LdaModel::fit(&feat, nrows, ncols, &is_decoy, DEFAULT_LDA_SHRINKAGE) {
+        Some(model) => {
+            let t = Instant::now();
+            let mut scores = vec![0.0f64; nrows];
+            model.score_all(&feat, nrows, &mut scores);
+            for (cand, &s) in data.iter_mut().zip(scores.iter()) {
+                cand.assign_score(s);
+            }
+            eprintln!("  LDA: scored {nrows} candidates in {:.2?}", t.elapsed());
+            lda_feature_stats(&names, &feat, nrows, model.coef())
+        }
+        None => {
+            tracing::error!("LDA fit failed (singular or empty class); scores left at zero");
+            vec![FoldStats {
+                fold: 0,
+                feature_stats: Vec::new(),
+                feature_importance: Vec::new(),
+            }]
+        }
+    };
+
+    let mut scored = data;
+    #[cfg(feature = "rayon")]
+    scored.par_sort_unstable_by(|a, b| b.get_score().total_cmp(&a.get_score()));
+    #[cfg(not(feature = "rayon"))]
+    scored.sort_unstable_by(|a, b| b.get_score().total_cmp(&a.get_score()));
+    assign_qval(&mut scored, |x| CompetedCandidate::get_score(x) as f32);
+
+    (scored.into_iter().map(|c| c.into_final()).collect(), stats)
+}
+
+/// Dump the raw feature matrix + labels for offline analysis. Best-effort:
+/// logs and returns on any I/O error rather than aborting the run.
+fn dump_feature_matrix(
+    prefix: &str,
+    base: &[f64],
+    nrows: usize,
+    names: &[&'static str],
+    is_decoy: &[bool],
+) {
+    use std::io::Write;
+    let write = || -> std::io::Result<()> {
+        let mut f = std::io::BufWriter::new(std::fs::File::create(format!("{prefix}.f64"))?);
+        // Header: nrows, ncols as u64 little-endian, then row-major f64.
+        f.write_all(&(nrows as u64).to_le_bytes())?;
+        f.write_all(&(names.len() as u64).to_le_bytes())?;
+        // SAFETY: transmuting &[f64] to &[u8] for a bulk write.
+        let bytes =
+            unsafe { std::slice::from_raw_parts(base.as_ptr() as *const u8, base.len() * 8) };
+        f.write_all(bytes)?;
+        f.flush()?;
+
+        let labels: Vec<u8> = is_decoy.iter().map(|&d| u8::from(!d)).collect();
+        std::fs::write(format!("{prefix}.labels"), &labels)?;
+        std::fs::write(format!("{prefix}.names.txt"), names.join("\n"))?;
+        Ok(())
+    };
+    match write() {
+        Ok(()) => eprintln!("  LDA: dumped feature matrix to {prefix}.{{f64,labels,names.txt}}"),
+        Err(e) => tracing::error!("feature dump failed: {e}"),
+    }
+}
+
+/// Predicate: does this feature's discriminative structure put the *best*
+/// value at zero, with both tails bad? Such signed features are useless to a
+/// single-sign linear discriminant until folded to their magnitude.
+fn is_center_better(name: &str) -> bool {
+    // Signed per-ion / precursor mass + mobility errors, RT residual, and the
+    // MS1-vs-MS2 mobility offset. Excludes already-magnitude features
+    // (`*_sq_*`, `*_mean_abs_error`, `calibrated_sq_delta_rt`).
+    name == "rt_err"
+        || name == "delta_ms1_ms2_mobility"
+        || name.starts_with("ms2_mz_err_")
+        || name.starts_with("ms2_mob_err_")
+        || name.starts_with("ms1_mz_err_")
+        || name.starts_with("ms1_mob_err_")
+}
+
+/// Replace each center-is-better column with its magnitude (`|x|`, NaN
+/// preserved) so a linear model can weight it monotonically.
+fn absolutize_center_better(base: &mut [f64], base_ncols: usize, base_names: &[&'static str]) {
+    let abs_cols: Vec<usize> = (0..base_ncols)
+        .filter(|&j| is_center_better(base_names[j]))
+        .collect();
+    if abs_cols.is_empty() {
+        return;
+    }
+    for row in base.chunks_exact_mut(base_ncols) {
+        for &j in &abs_cols {
+            row[j] = row[j].abs();
+        }
+    }
+}
+
+/// Fraction of rows that must be missing (and present) for a feature's
+/// missingness to earn its own indicator column. Below this it carries no
+/// signal; above `1 - this` it is ~always absent (equally useless).
+const MISSINGNESS_MIN_RATE: f64 = 0.01;
+
+/// Append a binary `<name>_isna` column (1.0 = the source value was non-finite)
+/// for every base feature whose missing rate lies in
+/// `[MISSINGNESS_MIN_RATE, 1 - MISSINGNESS_MIN_RATE]`. Returns the augmented
+/// row-major matrix and the extended name list.
+///
+/// Indicator names are interned via `Box::leak` (a handful of small strings,
+/// once per run) to satisfy the `&'static str` name contract shared with the
+/// GBM feature-stats path.
+fn augment_with_missingness(
+    base: &[f64],
+    nrows: usize,
+    base_names: &[&'static str],
+) -> (Vec<f64>, Vec<&'static str>) {
+    let base_ncols = base_names.len();
+    // Per-column NaN counts.
+    let mut nan = vec![0u64; base_ncols];
+    for row in base.chunks_exact(base_ncols) {
+        for (j, &v) in row.iter().enumerate() {
+            if !v.is_finite() {
+                nan[j] += 1;
+            }
+        }
+    }
+    let n = nrows.max(1) as f64;
+    let sel: Vec<usize> = (0..base_ncols)
+        .filter(|&j| {
+            let r = nan[j] as f64 / n;
+            r >= MISSINGNESS_MIN_RATE && r <= 1.0 - MISSINGNESS_MIN_RATE
+        })
+        .collect();
+    if sel.is_empty() {
+        return (base.to_vec(), base_names.to_vec());
+    }
+
+    let ncols = base_ncols + sel.len();
+    let mut names: Vec<&'static str> = base_names.to_vec();
+    for &j in &sel {
+        let nm: &'static str = Box::leak(format!("{}_isna", base_names[j]).into_boxed_str());
+        names.push(nm);
+    }
+
+    let mut out = vec![0.0f64; nrows * ncols];
+    for (i, row) in base.chunks_exact(base_ncols).enumerate() {
+        let obase = i * ncols;
+        out[obase..obase + base_ncols].copy_from_slice(row);
+        for (t, &j) in sel.iter().enumerate() {
+            out[obase + base_ncols + t] = if row[j].is_finite() { 0.0 } else { 1.0 };
+        }
+    }
+    (out, names)
+}
+
+/// Single-"fold" feature stats for the LDA path: per-feature finite means +
+/// NaN ratios, plus `|coef|` as the importance ranking (LDA weights in
+/// standardized space are directly interpretable as importance).
+fn lda_feature_stats(
+    names: &[&'static str],
+    feat: &[f64],
+    nrows: usize,
+    coef: &[f64],
+) -> RescoreFeatureStats {
+    let ncols = names.len();
+    let mut sums = vec![0.0f64; ncols];
+    let mut finite = vec![0u32; ncols];
+    let mut nan = vec![0u32; ncols];
+    for row in feat.chunks_exact(ncols) {
+        for j in 0..ncols {
+            let v = row[j];
+            if v.is_finite() {
+                sums[j] += v;
+                finite[j] += 1;
+            } else {
+                nan[j] += 1;
+            }
+        }
+    }
+    let n = nrows.max(1) as f32;
+    let feature_stats: Vec<FeatureStat> = (0..ncols)
+        .map(|j| FeatureStat {
+            name: names[j],
+            mean: if finite[j] > 0 {
+                (sums[j] / finite[j] as f64) as f32
+            } else {
+                f32::NAN
+            },
+            nan_ratio: nan[j] as f32 / n,
+        })
+        .collect();
+
+    let mut feature_importance: Vec<(&'static str, f32)> = names
+        .iter()
+        .zip(coef.iter())
+        .map(|(nm, c)| (*nm, c.abs() as f32))
+        .collect();
+    feature_importance.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    vec![FoldStats {
+        fold: 0,
+        feature_stats,
+        feature_importance,
+    }]
 }
 
 use crate::models::AA_COUNT_NAMES;

--- a/rust/timsseek_cli/src/processing.rs
+++ b/rust/timsseek_cli/src/processing.rs
@@ -24,6 +24,7 @@ use timsseek::ml::qvalues::report_qvalues_at_thresholds;
 use timsseek::ml::{
     RescoreFeatureStats,
     rescore,
+    rescore_lda,
 };
 use timsseek::rt_calibration::{
     CalibRtError,
@@ -384,7 +385,17 @@ pub fn execute_pipeline<I: ScorerQueriable>(
 
     // === PHASE 5: Rescore ===
     let step = TimedStep::begin("Phase 5: Rescore");
-    let (data, feature_stats) = rescore(competed);
+    // Model selectable at runtime; GBM is the default. `lda` = Sage-style
+    // shrinkage LDA (see timsseek::ml::lda), ~100x cheaper.
+    let use_lda = std::env::var("TIMSSEEK_RESCORE_MODEL")
+        .map(|v| v.eq_ignore_ascii_case("lda"))
+        .unwrap_or(false);
+    let (data, feature_stats) = if use_lda {
+        eprintln!("  (rescore model: LDA)");
+        rescore_lda(competed)
+    } else {
+        rescore(competed)
+    };
     let phase5_ms = step.finish().as_millis() as u64;
     alloc_track::snap!("Phase 5: Rescore");
 


### PR DESCRIPTION
## What

Exploration of faster Phase 5 rescoring. The GBM rescorer dominates the
pipeline (~180-220s of a ~300s run on the Skyline library). Two additive,
opt-in paths; the default GBM `rescore` is unchanged.

Not for merge yet - captures the exploration and leaves the tuning knobs in
place.

## Results (Skyline library, 250225 Hela off, 2.3M candidates)

GBM baseline on this run = 46539 targets @ 1% FDR, ~182s training.

    config                         targets@1%   %GBM    train    speedup
    default (1000 it, depth-6)       46539      100%     182s      1x
    GBM 200 it / 31 leaves / lr.10   45566      97.9%     66s      2.75x
    GBM 100 it / 15 leaves / lr.15   44160      94.9%     33s      5.5x
    LDA (linear ceiling)             37984      81.6%     ~10s     ~18x

## Path 1: env-tunable GBM config (the likely mergeable win)

The forust default (1000 iterations, depth-6, unlimited leaves) is heavily
over-provisioned. `GBMConfig::from_env` adds runtime overrides so the
accuracy/speed knob can be swept without recompiling:

    TIMSSEEK_GBM_ITERS  _MAX_DEPTH  _MAX_LEAVES  _LR  _EARLY_STOP

200 it / 31 leaves keeps 98% of IDs at 2.75x. Far better trade than LDA.

## Path 2: Sage-style shrinkage LDA (TIMSSEEK_RESCORE_MODEL=lda)

- Two-pass Fisher LDA, flat row-major matrix, rayon-parallel and
  deterministic (fixed-chunk reductions). Ridge shrinkage keeps the
  collinear 108-dim feature set solvable without pruning.
- Rank-based inverse-normal transform (van der Waerden) for the per-feature
  normality assumption; missingness indicators + abs() of signed error
  features as linear-friendly feature engineering.
- ~40x faster (Phase 5 ~180s -> ~10s), but caps at ~82% of GBM IDs on the
  hard Skyline library. This is a genuine linear-model ceiling, confirmed
  offline against sklearn LDA / QDA / logistic (all cluster at 79-82%);
  HistGradientBoosting matches forust at 99.6%, so trees are required for
  the last ~18%. LDA is useful for QC/triage, not a drop-in replacement.

## Methodology

`TIMSSEEK_LDA_DUMP=/prefix` writes the raw feature matrix + labels, which
drove an offline numpy/sklearn harness (feature selection, transforms,
model zoo, tree-config sweep). Kept local under bench_out/ (gitignored).
Feature selection did not help - LDA wants all 108 features; INT is worth
~+5600 IDs; the gap is model capacity, not FE.

## Open question

Which operating point should become the default: keep 1000/depth-6, or
move to ~200/31 (2.75x, -2% IDs)? Leaving that decision for the merge.
