### PR TITLE
feat(centroiding): per-level MS1/MS2 config with tuned defaults

### DIFF
--- a/rust/tims_stage/src/load.rs
+++ b/rust/tims_stage/src/load.rs
@@ -22,7 +22,7 @@ use timscentroid::reader::{
     local_uri,
 };
 use timscentroid::{
-    CentroidingConfig,
+    IndexingCentroidingConfig,
     IndexedTimstofPeaks,
     StorageProvider,
 };
@@ -61,7 +61,7 @@ pub enum LoadRawError {
 pub fn load_raw(
     uri: &str,
     backend: &dyn StagingBackend,
-    cfg: &CentroidingConfig,
+    cfg: &IndexingCentroidingConfig,
 ) -> Result<RawRead, LoadRawError> {
     let registry = ReaderRegistry::with_builtins();
 

--- a/rust/timscentroid/README.md
+++ b/rust/timscentroid/README.md
@@ -7,14 +7,14 @@ Efficient indexing and lazy loading for timsTOF mass spectrometry data.
 ### Basic Usage (Local Files)
 
 ```rust
-use timscentroid::{IndexedTimstofPeaks, CentroidingConfig};
+use timscentroid::{IndexedTimstofPeaks, IndexingCentroidingConfig};
 use timscentroid::lazy::LazyIndexedTimstofPeaks;
 use timscentroid::utils::{TupleRange, OptionallyRestricted::*};
 
-// 1. Index your timsTOF data
+// 1. Index your timsTOF data (per-level MS1/MS2 config; `::default()` is tuned)
 let index = IndexedTimstofPeaks::from_timstof_file(
     &file,
-    CentroidingConfig::default()
+    IndexingCentroidingConfig::default()
 );
 
 // 2. Save to disk
@@ -182,12 +182,17 @@ Smaller row groups = more granular queries but more overhead.
 ### Centroiding Settings
 
 ```rust
-use timscentroid::CentroidingConfig;
+use timscentroid::{CentroidingConfig, IndexingCentroidingConfig};
 
-let config = CentroidingConfig {
-    min_intensity: 100.0,
-    min_peaks_per_group: 3,
-    ..Default::default()
+// MS1 and MS2 are centroided independently. Override per level:
+let config = IndexingCentroidingConfig {
+    ms1: CentroidingConfig { mz_ppm_tol: 0.5, im_pct_tol: 2.0, ..Default::default() },
+    ms2: CentroidingConfig {
+        mz_ppm_tol: 1.0,
+        im_pct_tol: 3.0,
+        max_peaks: 50_000,
+        early_stop_iterations: 0, // disable early-stop
+    },
 };
 
 let index = IndexedTimstofPeaks::from_timstof_file(&file, config);

--- a/rust/timscentroid/examples/indexing.rs
+++ b/rust/timscentroid/examples/indexing.rs
@@ -2,6 +2,7 @@ use half::f16;
 use timscentroid::utils::OptionallyRestricted;
 use timscentroid::{
     CentroidingConfig,
+    IndexingCentroidingConfig,
     IndexedTimstofPeaks,
 };
 use timsrust::TimsTofPath;
@@ -29,7 +30,7 @@ fn main() {
         early_stop_iterations: 200,
     };
     println!("Indexing with config: {:#?}", centroiding_config);
-    let (index, index_stats) = IndexedTimstofPeaks::from_timstof_file(&file, centroiding_config);
+    let (index, index_stats) = IndexedTimstofPeaks::from_timstof_file(&file, IndexingCentroidingConfig::uniform(centroiding_config));
     println!("Indexing Stats: {}", index_stats);
 
     test_querying(&index);

--- a/rust/timscentroid/examples/row_group_benchmark.rs
+++ b/rust/timscentroid/examples/row_group_benchmark.rs
@@ -13,6 +13,7 @@ use timscentroid::utils::{
 use timscentroid::{
     CentroidingConfig,
     IndexedTimstofPeaks,
+    IndexingCentroidingConfig,
     StorageLocation,
 };
 use timsrust::TimsTofPath;
@@ -54,7 +55,7 @@ fn main() {
     };
 
     let start = std::time::Instant::now();
-    let (index, stats) = IndexedTimstofPeaks::from_timstof_file(&file, config);
+    let (index, stats) = IndexedTimstofPeaks::from_timstof_file(&file, IndexingCentroidingConfig::uniform(config));
     println!("Indexed in {:?}: {}\n", start.elapsed(), stats);
 
     // Generate deterministic queries

--- a/rust/timscentroid/examples/serialization.rs
+++ b/rust/timscentroid/examples/serialization.rs
@@ -3,6 +3,7 @@ use timscentroid::utils::OptionallyRestricted;
 use timscentroid::{
     CentroidingConfig,
     IndexedTimstofPeaks,
+    IndexingCentroidingConfig,
     StorageLocation,
 };
 use timsrust::TimsTofPath;
@@ -35,7 +36,7 @@ fn main() {
 
     let start_centroid = std::time::Instant::now();
     let (index_original, index_stats) =
-        IndexedTimstofPeaks::from_timstof_file(&file, centroiding_config);
+        IndexedTimstofPeaks::from_timstof_file(&file, IndexingCentroidingConfig::uniform(centroiding_config));
     let centroid_time = start_centroid.elapsed();
 
     println!("Indexing Stats: {}", index_stats);

--- a/rust/timscentroid/src/centroiding.rs
+++ b/rust/timscentroid/src/centroiding.rs
@@ -43,7 +43,11 @@ pub struct CentroidingConfig {
     /// Number of consecutive iterations with no new peaks clustered
     /// after which the centroiding will stop early (instead of going
     /// through all peaks, which will very likely be noise).
-    /// A number ~200 seems to work well in practice.
+    /// A number ~200 seems to work well in practice. **`0` disables
+    /// early-stop** — the whole frame is clustered and only `max_peaks`
+    /// can truncate it. Disabling is the right choice under a tight
+    /// `mz_ppm_tol`, where most peaks are singletons and early-stop would
+    /// otherwise clip real signal (see `IndexingCentroidingConfig`).
     pub early_stop_iterations: u32,
 }
 
@@ -54,6 +58,50 @@ impl Default for CentroidingConfig {
             mz_ppm_tol: 5.0,
             im_pct_tol: 3.0,
             early_stop_iterations: 200,
+        }
+    }
+}
+
+/// Per-MS-level centroiding configuration for building an index.
+///
+/// MS1 and MS2 are centroided independently: MS1 favors precursor m/z
+/// precision (peak counts are small, so a tight merge is cheap), while MS2
+/// keeps a tight m/z merge with early-stop disabled and a moderate
+/// `max_peaks` cap — the setting that preserves fragment signal without the
+/// peak-count explosion of a full raw pass.
+///
+/// Use [`IndexingCentroidingConfig::uniform`] to apply one config to both
+/// levels (e.g. for non-TIMS sources or tests).
+#[derive(Clone, Copy, Debug)]
+pub struct IndexingCentroidingConfig {
+    pub ms1: CentroidingConfig,
+    pub ms2: CentroidingConfig,
+}
+
+impl IndexingCentroidingConfig {
+    /// Apply the same `CentroidingConfig` to both MS levels.
+    pub fn uniform(cfg: CentroidingConfig) -> Self {
+        Self { ms1: cfg, ms2: cfg }
+    }
+}
+
+impl Default for IndexingCentroidingConfig {
+    /// Tuned defaults from the centroiding sensitivity sweep (timsTOF):
+    /// MS1 `0.5ppm / 2%`; MS2 `1ppm / 3%`, `max_peaks=50k`, early-stop off.
+    fn default() -> Self {
+        Self {
+            ms1: CentroidingConfig {
+                max_peaks: 20_000,
+                mz_ppm_tol: 0.5,
+                im_pct_tol: 2.0,
+                early_stop_iterations: 200,
+            },
+            ms2: CentroidingConfig {
+                max_peaks: 50_000,
+                mz_ppm_tol: 1.0,
+                im_pct_tol: 3.0,
+                early_stop_iterations: 0, // disabled — see field doc
+            },
         }
     }
 }
@@ -453,7 +501,11 @@ impl<T1: ConvertableDomain, T2: ConvertableDomain> PeakCentroider<T1, T2> {
 
             global_num_included += num_includable;
 
-            if is_self_parent {
+            // `early_stop_iterations == 0` disables early-stop entirely: the
+            // whole frame is clustered (only `max_peaks` can still truncate).
+            // The guard also avoids the `0 - 1` u32 underflow that a zero
+            // config would otherwise hit on the first lonely peak.
+            if is_self_parent && self.early_stop_iterations != 0 {
                 if num_includable < 3 {
                     // If we have only incliuded 'self' peaks for MAX_EARLY_STOP
                     // iterations consecutively, we can stop early.

--- a/rust/timscentroid/src/indexing.rs
+++ b/rust/timscentroid/src/indexing.rs
@@ -40,6 +40,7 @@ pub use timsrust::TimsTofPath;
 use crate::centroiding::{
     AggregatedClusteringSummary,
     CentroidingConfig,
+    IndexingCentroidingConfig,
     PeakCentroider,
 };
 use crate::geometry::QuadrupoleIsolationScheme;
@@ -159,20 +160,21 @@ impl IndexedTimstofPeaks {
 
     pub fn from_timstof_file(
         file: &TimsTofPath,
-        centroiding_config: CentroidingConfig,
+        centroiding_config: IndexingCentroidingConfig,
     ) -> (Self, IndexBuildingStats) {
         let frame_reader = file.load_frame_reader().unwrap();
         let metadata = file.load_metadata().unwrap();
 
-        // Read MS1 peaks
+        // Read MS1 peaks (MS1-specific centroiding config)
         let st = std::time::Instant::now();
-        let (ms1_peaks, ms1_summ) = Self::read_ms1(&frame_reader, &metadata, centroiding_config);
+        let (ms1_peaks, ms1_summ) =
+            Self::read_ms1(&frame_reader, &metadata, centroiding_config.ms1);
         let read_time_ms1 = st.elapsed();
 
-        // Read MS2 peaks organized by window groups
+        // Read MS2 peaks organized by window groups (MS2-specific config)
         let st = std::time::Instant::now();
         let (ms2_window_groups, ms2_summ) =
-            Self::read_ms2_window_groups(&frame_reader, &metadata, centroiding_config).unwrap();
+            Self::read_ms2_window_groups(&frame_reader, &metadata, centroiding_config.ms2).unwrap();
         let read_time_ms2 = st.elapsed();
 
         let out = Self {

--- a/rust/timscentroid/src/lib.rs
+++ b/rust/timscentroid/src/lib.rs
@@ -25,7 +25,10 @@ pub use indexing::{
 };
 
 #[doc(inline)]
-pub use centroiding::CentroidingConfig;
+pub use centroiding::{
+    CentroidingConfig,
+    IndexingCentroidingConfig,
+};
 
 #[doc(inline)]
 pub use dimension::MobilityKind;

--- a/rust/timscentroid/src/reader/mod.rs
+++ b/rust/timscentroid/src/reader/mod.rs
@@ -21,7 +21,7 @@ use std::path::{
 use http::Uri;
 use url::Url;
 
-use crate::centroiding::CentroidingConfig;
+use crate::centroiding::IndexingCentroidingConfig;
 use crate::indexing::IndexedTimstofPeaks;
 
 /// Outcome of a cheap URI-only claim check.
@@ -154,7 +154,7 @@ pub trait RawReader: Send + Sync {
     fn read(
         &self,
         src: &ResolvedSource,
-        cfg: &CentroidingConfig,
+        cfg: &IndexingCentroidingConfig,
     ) -> Result<IndexedTimstofPeaks, ReadError>;
 }
 
@@ -283,7 +283,7 @@ impl RawReader for BrukerTdfReader {
     fn read(
         &self,
         src: &ResolvedSource,
-        cfg: &CentroidingConfig,
+        cfg: &IndexingCentroidingConfig,
     ) -> Result<IndexedTimstofPeaks, ReadError> {
         let path = src.entry_path();
         let path_str = path

--- a/rust/timscentroid/src/reader/mzdata.rs
+++ b/rust/timscentroid/src/reader/mzdata.rs
@@ -27,7 +27,7 @@ use super::{
     Sniff,
     path_ends_with,
 };
-use crate::centroiding::CentroidingConfig;
+use crate::centroiding::IndexingCentroidingConfig;
 use crate::dimension::MobilityKind;
 use crate::geometry::QuadrupoleIsolationScheme;
 use crate::indexing::{
@@ -94,7 +94,7 @@ impl RawReader for MzdataReader {
     fn read(
         &self,
         src: &ResolvedSource,
-        cfg: &CentroidingConfig,
+        cfg: &IndexingCentroidingConfig,
     ) -> Result<IndexedTimstofPeaks, ReadError> {
         from_mzml_file(&src.entry_path(), cfg)
     }
@@ -147,7 +147,7 @@ struct WindowAccum {
 /// `IndexedTimstofPeaks::from_timstof_file`.
 pub fn from_mzml_file(
     path: &Path,
-    _cfg: &CentroidingConfig,
+    _cfg: &IndexingCentroidingConfig,
 ) -> Result<IndexedTimstofPeaks, ReadError> {
     let file = std::fs::File::open(path)?;
     let reader = MzMLReader::new(BufReader::new(file));

--- a/rust/timscentroid/src/serialization/mod.rs
+++ b/rust/timscentroid/src/serialization/mod.rs
@@ -5,14 +5,14 @@
 //! # Examples
 //!
 //! ```no_run
-//! use timscentroid::{IndexedTimstofPeaks, CentroidingConfig, StorageLocation};
+//! use timscentroid::{IndexedTimstofPeaks, IndexingCentroidingConfig, StorageLocation};
 //! use timscentroid::serialization::SerializationConfig;
 //! use timsrust::TimsTofPath;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! // Index peaks from raw data
+//! // Index peaks from raw data (per-level MS1/MS2 config; `::default()` is tuned)
 //! let file = TimsTofPath::new("data.d")?;
-//! let config = CentroidingConfig::default();
+//! let config = IndexingCentroidingConfig::default();
 //! let (index, _) = IndexedTimstofPeaks::from_timstof_file(&file, config);
 //!
 //! // Save with default settings (balanced speed/size)

--- a/rust/timscentroid/tests/mzdata_ingest.rs
+++ b/rust/timscentroid/tests/mzdata_ingest.rs
@@ -16,7 +16,7 @@ use timscentroid::reader::mzdata::from_mzml_file;
 fn ingests_real_thermo_dia_mzml() {
     let path =
         std::env::var("MZML_TEST_PATH").expect("set MZML_TEST_PATH to a local Thermo DIA .mzML");
-    let cfg = timscentroid::CentroidingConfig::default();
+    let cfg = timscentroid::IndexingCentroidingConfig::default();
     let idx = from_mzml_file(std::path::Path::new(&path), &cfg)
         .expect("from_mzml_file should succeed on a centroided DIA mzML");
 

--- a/rust/timscentroid/tests/mzml_synthetic.rs
+++ b/rust/timscentroid/tests/mzml_synthetic.rs
@@ -122,7 +122,7 @@ fn ingests_synthetic_dia_mzml() {
     let path = dir.path().join("synthetic.mzML");
     std::fs::write(&path, synthetic_dia_mzml()).unwrap();
 
-    let cfg = timscentroid::CentroidingConfig::default();
+    let cfg = timscentroid::IndexingCentroidingConfig::default();
     let idx = from_mzml_file(&path, &cfg).expect("synthetic DIA mzML should ingest");
 
     // No ion-mobility axis declared → Absent.

--- a/rust/timsquery/src/lib.rs
+++ b/rust/timsquery/src/lib.rs
@@ -34,6 +34,7 @@ pub use timscentroid::utils::OptionallyRestricted;
 pub use timscentroid::{
     CentroidingConfig,
     IndexedTimstofPeaks,
+    IndexingCentroidingConfig,
     TimsTofPath,
 };
 

--- a/rust/timsquery/src/serde/index_serde.rs
+++ b/rust/timsquery/src/serde/index_serde.rs
@@ -65,17 +65,13 @@
 //!
 //! ```no_run
 //! use timsquery::serde::TimsIndexReader;
-//! use timsquery::CentroidingConfig;
+//! use timsquery::IndexingCentroidingConfig;
 //! use timscentroid::serialization::SerializationConfig;
 //!
 //! let index = TimsIndexReader::new()
 //!     .with_local_cache("/tmp/cache")
-//!     .with_centroiding_config(CentroidingConfig {
-//!         max_peaks: 50_000,
-//!         mz_ppm_tol: 10.0,
-//!         im_pct_tol: 5.0,
-//!         early_stop_iterations: 200,
-//!     })
+//!     // Per-level MS1/MS2 config; `::default()` is the tuned recommendation.
+//!     .with_centroiding_config(IndexingCentroidingConfig::default())
 //!     .with_serialization_config(SerializationConfig::default())
 //!     .read_index("data.d").unwrap();
 //! ```
@@ -113,7 +109,7 @@
 //! ```
 
 use crate::{
-    CentroidingConfig,
+    IndexingCentroidingConfig,
     IndexedTimstofPeaks,
 };
 use std::path::{
@@ -260,7 +256,7 @@ pub struct IndexLoadConfig {
     pub cache_location: CacheLocation,
 
     /// Centroiding configuration (only used when loading raw .d files)
-    pub centroiding_config: Option<CentroidingConfig>,
+    pub centroiding_config: Option<IndexingCentroidingConfig>,
 
     /// Serialization configuration
     pub serialization_config: SerializationConfig,
@@ -389,7 +385,7 @@ impl CacheLocation {
 pub struct TimsIndexReader {
     cache_location: CacheLocation,
     write_missing_cache: bool,
-    centroiding_config: Option<CentroidingConfig>,
+    centroiding_config: Option<IndexingCentroidingConfig>,
     serialization_config: SerializationConfig,
 }
 
@@ -446,7 +442,7 @@ impl TimsIndexReader {
     }
 
     /// Set custom centroiding configuration
-    pub fn with_centroiding_config(mut self, config: CentroidingConfig) -> Self {
+    pub fn with_centroiding_config(mut self, config: IndexingCentroidingConfig) -> Self {
         self.centroiding_config = Some(config);
         self
     }
@@ -547,12 +543,9 @@ impl TimsIndexReader {
         }
 
         // Build via the shared registry core (sniff-first; TDF, mzML, ...).
-        let centroiding_config = self.centroiding_config.unwrap_or(CentroidingConfig {
-            max_peaks: 50_000,
-            mz_ppm_tol: 10.0,
-            im_pct_tol: 5.0,
-            early_stop_iterations: 200,
-        });
+        let centroiding_config = self
+            .centroiding_config
+            .unwrap_or_else(IndexingCentroidingConfig::default);
         info!("Starting centroiding + load of the raw data (might take a min)");
         let path_str = path.to_str().ok_or_else(|| {
             crate::errors::DataReadingError::RawReadError(format!("non-UTF-8 path: {path:?}"))
@@ -873,7 +866,7 @@ pub fn load_index(
     uri: &str,
     backend: &dyn StagingBackend,
     save_sidecar: bool,
-    centroid_cfg: CentroidingConfig,
+    centroid_cfg: IndexingCentroidingConfig,
 ) -> Result<(IndexedTimstofPeaks, IndexSource), LoadIndexError> {
     let canon = canonical_uri(uri);
     match resolve(&canon)? {

--- a/rust/timsquery/tests/load_index.rs
+++ b/rust/timsquery/tests/load_index.rs
@@ -4,7 +4,7 @@ use tims_stage::{
     PerRunTempdir,
     StagingConfig,
 };
-use timscentroid::CentroidingConfig;
+use timscentroid::IndexingCentroidingConfig;
 use timsquery::load_index;
 
 fn fixture_dotd() -> PathBuf {
@@ -18,7 +18,7 @@ fn fixture_dotd() -> PathBuf {
 fn load_index_from_local_dotd() {
     let backend = PerRunTempdir::new(StagingConfig::default()).unwrap();
     let uri = fixture_dotd().to_string_lossy().to_string();
-    let (_idx, _) = load_index(&uri, &backend, false, CentroidingConfig::default())
+    let (_idx, _) = load_index(&uri, &backend, false, IndexingCentroidingConfig::default())
         .expect("load_index should succeed");
 }
 
@@ -31,12 +31,12 @@ fn sidecar_roundtrip() {
     let dotd_copy = work.path().join("sample.d");
     copy_dir_recursive(&dotd, &dotd_copy).unwrap();
     let uri = dotd_copy.to_string_lossy().to_string();
-    let (_idx1, _) = load_index(&uri, &backend, true, CentroidingConfig::default()).unwrap();
+    let (_idx1, _) = load_index(&uri, &backend, true, IndexingCentroidingConfig::default()).unwrap();
     assert!(
         work.path().join("sample.d.idx/metadata.json").is_file(),
         "sidecar .idx should contain metadata.json after build"
     );
-    let (_idx2, _) = load_index(&uri, &backend, false, CentroidingConfig::default()).unwrap();
+    let (_idx2, _) = load_index(&uri, &backend, false, IndexingCentroidingConfig::default()).unwrap();
 }
 
 fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {

--- a/rust/timsseek_cli/src/main.rs
+++ b/rust/timsseek_cli/src/main.rs
@@ -6,7 +6,7 @@ mod processing;
 use clap::Parser;
 use timsquery::utils::TupleRange;
 use timsquery::{
-    CentroidingConfig,
+    IndexingCentroidingConfig,
     IndexedTimstofPeaks,
     load_index,
 };
@@ -363,7 +363,7 @@ fn process_single_file(
 
     let step = TimedStep::begin("Loading index");
     let (index, index_source) =
-        load_index(raw_uri, backend, save_sidecar, CentroidingConfig::default()).map_err(|e| {
+        load_index(raw_uri, backend, save_sidecar, IndexingCentroidingConfig::default()).map_err(|e| {
             errors::CliError::Io {
                 source: format!("load_index({raw_uri}): {e}"),
                 path: Some(raw_uri.to_string()),


### PR DESCRIPTION
Adds `IndexingCentroidingConfig { ms1, ms2 }` so MS1 and MS2 are centroided independently (was one shared config), threaded through the build path; single-config callers use `::uniform`.

New defaults from the centroiding sweep: MS1 `0.5ppm/2%`; MS2 `1ppm/3%`, `max_peaks=50k`, early-stop off. `early_stop_iterations=0` now disables early-stop (also fixes a latent u32 underflow).
