### PR TITLE
fix(mass): use 13C-12C isotope spacing, not free-neutron mass

### DIFF
--- a/rust/timsquery/src/models/elution_group.rs
+++ b/rust/timsquery/src/models/elution_group.rs
@@ -3,7 +3,7 @@ use crate::models::elution_group::tims_elution_group_builder::{
     SetPrecursorMonoMz,
 };
 use crate::traits::KeyLike;
-use crate::utils::constants::NEUTRON_MASS;
+use crate::utils::constants::C13_C12_MASS_DIFF;
 use serde::{
     Deserialize,
     Serialize,
@@ -176,7 +176,7 @@ impl<T: KeyLike> TimsElutionGroup<T> {
     }
 
     fn precursor_mz_iter(&self) -> impl Iterator<Item = f64> + '_ {
-        let offset = NEUTRON_MASS / self.precursor_charge as f64;
+        let offset = C13_C12_MASS_DIFF / self.precursor_charge as f64;
         self.precursor_labels.iter().map(move |isotope_index| {
             let idx = *isotope_index;
             self.precursor_mono_mz + (offset * idx as f64)

--- a/rust/timsquery/src/models/query_handle.rs
+++ b/rust/timsquery/src/models/query_handle.rs
@@ -11,7 +11,7 @@ use crate::traits::{
     KeyLike,
     QueryGeom,
 };
-use crate::utils::constants::NEUTRON_MASS;
+use crate::utils::constants::C13_C12_MASS_DIFF;
 
 /// Flyweight handle over a `QueryCollection` arena: `lib` borrows (or owns via
 /// `Arc`) the arena, `handle` packs the target index and decoy variant. No
@@ -78,7 +78,7 @@ impl<Lib: Deref<Target = QueryCollection<L>>, L: KeyLike + DecoyShift> Query<Lib
     /// Spacing between adjacent isotope peaks in m/z for this precursor's charge.
     fn isotope_step(&self) -> f64 {
         let charge = self.geom().charge[self.target_idx()] as f64;
-        NEUTRON_MASS / charge
+        C13_C12_MASS_DIFF / charge
     }
 }
 
@@ -214,10 +214,10 @@ mod tests {
     #[test]
     fn precursor_mz_limits_span_isotope_envelope() {
         // n_isotopes=3, charge 2, mono 654.855 -> limits span isotopes 0..3,
-        // i.e. (mono, mono + 2*NEUTRON_MASS/2).
+        // i.e. (mono, mono + 2*C13_C12_MASS_DIFF/2).
         let lib = one_target_lib();
         let q = Query::new(&lib, 0, 0);
-        let step = NEUTRON_MASS / 2.0;
+        let step = C13_C12_MASS_DIFF / 2.0;
         let (lo, hi) = q.precursor_mz_limits();
         assert!((lo - 654.855).abs() < 1e-9);
         assert!((hi - (654.855 + 2.0 * step)).abs() < 1e-9);
@@ -264,7 +264,7 @@ mod tests {
         // limits shift by the same amount and keep the same width.
         let lib = one_target_lib();
         let q = Query::new(&lib, 0, 1);
-        let step = NEUTRON_MASS / 2.0;
+        let step = C13_C12_MASS_DIFF / 2.0;
         let mono = 654.855 + 14.0 / 2.0;
         let (lo, hi) = q.precursor_mz_limits();
         assert!((lo - mono).abs() < 1e-9);

--- a/rust/timsquery/src/utils/constants.rs
+++ b/rust/timsquery/src/utils/constants.rs
@@ -1,2 +1,7 @@
-pub const NEUTRON_MASS: f64 = 1.00866491588;
+/// Mass difference between the 13C and 12C carbon isotopes (Da), i.e. the
+/// spacing between adjacent peaks of a peptide isotope envelope. This is NOT
+/// the free-neutron mass (1.00866 Da) — using that overstates the spacing by
+/// ~0.0053 Da/step, biasing measured M+1/M+2 m/z errors several ppm negative.
+/// Value: 13C = 13.0033548378 u (AME2020 / NIST), 12C ≡ 12; difference below.
+pub const C13_C12_MASS_DIFF: f64 = 1.0033548378;
 pub const PROTON_MASS: f64 = 1.007276466;

--- a/rust/timsseek/src/utils/elution_group_ops.rs
+++ b/rust/timsseek/src/utils/elution_group_ops.rs
@@ -1,10 +1,10 @@
 use timsquery::TimsElutionGroup;
-use timsquery::utils::constants::NEUTRON_MASS;
+use timsquery::utils::constants::C13_C12_MASS_DIFF;
 
 use crate::IonAnnot;
 
 /// Buffer-override variant of `isotope_offset_fragments`: reset `dst` from `src`
-/// (reusing Vec/TinyVec capacity), then apply a neutron-mass m/z shift and label
+/// (reusing Vec/TinyVec capacity), then apply an isotope-spacing m/z shift and label
 /// rewrite to every fragment in place. Zero alloc after warm-up.
 ///
 /// `dst` and `src` must refer to distinct TimsElutionGroup values — typical use
@@ -19,7 +19,7 @@ pub fn apply_isotope_offset_fragments_into(
         let new_ions = k.try_with_offset_neutrons(offset).expect(
             "Isotope offset overflow - this should never happen with realistic isotope offsets",
         );
-        let mz_offset = (NEUTRON_MASS / k.get_charge() as f64) * offset as f64;
+        let mz_offset = (C13_C12_MASS_DIFF / k.get_charge() as f64) * offset as f64;
         *v += mz_offset;
         *k = new_ions;
     }


### PR DESCRIPTION
Isotope-envelope m/z (precursor isotope references, isotope step, precursor m/z limits, decoy isotope offset) used NEUTRON_MASS = 1.00866491588 Da, the free-neutron mass, as the adjacent-isotope peak spacing. The correct value is the 13C-12C mass difference, 1.0033548378 Da (13C = 13.0033548378 u, AME2020/NIST; matches MaxQuant/DIA-NN).

The neutron value overstates the spacing by ~0.0053 Da/step, so M+1/M+2 reference m/z land high and read several ppm negative. Precursor calibration takes the intensity-weighted mean across M+0/M+1/M+2, so that bias pulls the extraction-window center off zero (worse on Orbitrap-Astral, where MS1 and MS2 use separate detectors).

Renames NEUTRON_MASS -> C13_C12_MASS_DIFF. No code used the neutron mass legitimately; remaining "neutron" references are integer isotope-index offsets (M+n counting), no mass involved.

Measured, small Astral mzML run (LDA rescore, deterministic):
- calibration m/z error median: -2.36 -> -0.16 ppm
- m/z window: (12.2, 7.5) -> (10.4, 10.1) ppm
- IDs @ 1% FDR: 24267 -> 24684